### PR TITLE
README: Refer to the blog post

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 `grease` is a CLI tool that checks properties about binaries using under-constrained symbolic execution.
 
-For more information, see [the documentation](https://galoisinc.github.io/grease).
+For more information, see [the blog post introducing GREASE](https://www.galois.com/articles/introducing-grease), or [the documentation](https://galoisinc.github.io/grease).
 
 ## Acknowledgements
 


### PR DESCRIPTION
I don't actually think it's necessary to refer to this in the user docs themselves, given that the vast majority of the blog post content is just lifted from those same docs.

Fixes #59.