### PR TITLE
doc: Add GitHub URL to mdBook output

### DIFF
--- a/doc/book.toml
+++ b/doc/book.toml
@@ -4,3 +4,6 @@ language = "en"
 multilingual = false
 src = "."
 title = "GREASE"
+
+[output.html]
+git-repository-url = "https://github.com/GaloisInc/grease"


### PR DESCRIPTION
This puts a little GitHub icon in the top-right that folks can click on to get to the repo.