### PR TITLE
Revert "CI: Disable ubuntu-22.04-arm Docker job for now"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,11 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         # Cover both x86-64 and ARM64.
-        #
-        # For now, we disable the ARM64 job, as ARM64 Ubuntu runners are only
-        # available in public repos. Once we make this repo public, we can
-        # re-enable it. (#55)
-        os: [ubuntu-22.04] #, ubuntu-22.04-arm]
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Now that the `grease` repo is public, we can use Ubuntu ARM runners on GitHub Actions (which are still in public beta as of the time of writing). Fixes https://github.com/GaloisInc/grease/issues/55.