### PR TITLE
Remove `ArchRepr`

### DIFF
--- a/src/Grease/Macaw/Arch.hs
+++ b/src/Grease/Macaw/Arch.hs
@@ -3,20 +3,17 @@ Copyright        : (c) Galois, Inc. 2024
 Maintainer       : GREASE Maintainers <grease@galois.com>
 -}
 
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE TypeFamilies #-}
 
 module Grease.Macaw.Arch
-  ( ArchRepr(.., PPC32Repr, PPC64Repr)
-  , ArchRegs
+  ( ArchRegs
   , ArchRegCFG
   , ArchRegCFGMap
   , ArchCFG
   , ArchResult
   , ArchReloc
   , ArchContext(..)
-  , archRepr
   , archEndianness
   , archGetIP
   , archInfo
@@ -74,15 +71,6 @@ import           Data.Macaw.Types (BVType)
 import qualified Data.Macaw.Symbolic as Symbolic
 import qualified Data.Macaw.Memory as Symbolic
 
--- macaw-aarch32
-import qualified Data.Macaw.ARM as ARM (ARM)
-
--- macaw-ppc
-import qualified Data.Macaw.PPC as PPC
-
--- macaw-x86
-import qualified Data.Macaw.X86 as X86 (X86_64)
-
 -- stubs
 import qualified Stubs.Common as Stubs
 import qualified Stubs.FunctionOverride as Stubs
@@ -91,22 +79,6 @@ import Grease.Macaw.Load.Relocation (RelocType)
 import Grease.Macaw.RegName (RegName)
 import Grease.Shape.NoTag (NoTag)
 import Grease.Shape.Pointer (PtrShape)
-
--- | Run-time representative of supported architectures, used to provide
--- architecture-specific functionality in code that is mostly architecture
--- generic.
-data ArchRepr arch where
-  ARMRepr :: ArchRepr ARM.ARM
-  PPCRepr :: PPC.VariantRepr v -> ArchRepr (PPC.AnyPPC v)
-  X86Repr :: ArchRepr X86.X86_64
-
-pattern PPC32Repr :: () => (arch ~ PPC.PPC32) => ArchRepr arch
-pattern PPC32Repr = PPCRepr PPC.V32Repr
-
-pattern PPC64Repr :: () => (arch ~ PPC.PPC64) => ArchRepr arch
-pattern PPC64Repr = PPCRepr PPC.V64Repr
-
-{-# COMPLETE ARMRepr, PPC32Repr, PPC64Repr, X86Repr #-}
 
 type ArchRegs sym arch = Ctx.Assignment (C.RegValue' sym) (Symbolic.MacawCrucibleRegTypes arch)
 
@@ -135,8 +107,7 @@ type family ArchReloc arch :: Type
 -- 'Stubs.FunctionABI' data type from @stubs-common@, but it is different enough
 -- to warrant being a separate data type.
 data ArchContext arch = ArchContext
-  { _archRepr :: ArchRepr arch
-  , _archInfo :: MI.ArchitectureInfo arch
+  { _archInfo :: MI.ArchitectureInfo arch
   , _archEndianness :: Mem.EndianForm
   , _archGetIP ::
       forall sym.

--- a/src/Grease/Macaw/Arch/AArch32.hs
+++ b/src/Grease/Macaw/Arch/AArch32.hs
@@ -50,7 +50,7 @@ import qualified Stubs.Memory.AArch32.Linux as Stubs
 import qualified Stubs.Syscall.AArch32.Linux as Stubs
 import qualified Stubs.Syscall.Names.AArch32.Linux as Stubs
 
-import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRepr(ARMRepr))
+import Grease.Macaw.Arch (ArchContext(..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType(..))
 import Grease.Macaw.RegName (RegName(..))
 import Grease.Options (ExtraStackSlots)
@@ -82,8 +82,7 @@ armCtx halloc mbReturnAddr stackArgSlots = do
             Map.empty
   return
     ArchContext
-      { _archRepr = ARMRepr
-      , _archInfo = ARM.arm_linux_info
+      { _archInfo = ARM.arm_linux_info
       , _archEndianness = Mem.LittleEndian
       , _archGetIP = \regs -> do
           let C.RV (Mem.LLVMPointer _base off) = ARM.Symbolic.lookupReg ARM.pc regs

--- a/src/Grease/Macaw/Arch/AArch32.hs
+++ b/src/Grease/Macaw/Arch/AArch32.hs
@@ -103,6 +103,7 @@ armCtx halloc mbReturnAddr stackArgSlots = do
       , _archStackPtrShape = armStackPtrShape stackArgSlots
       , _archInitGlobals = Stubs.aarch32LinuxInitGlobals tlsGlob
       , _archRegOverrides = regOverrides
+      , _archOffsetStackPointerPostCall = pure
       }
 
 armRelocSupported :: EE.ARM32_RelocationType -> Maybe RelocType

--- a/src/Grease/Macaw/Arch/PPC32.hs
+++ b/src/Grease/Macaw/Arch/PPC32.hs
@@ -105,6 +105,7 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
       , _archStackPtrShape = ppcStackPtrShape (bytes32LE <$> mbReturnAddr) stackArgSlots
       , _archInitGlobals = \_ mem -> pure (mem, C.emptyGlobals)
       , _archRegOverrides = regOverrides
+      , _archOffsetStackPointerPostCall = pure
       }
 
 ppc32RelocSupported :: EE.PPC32_RelocationType -> Maybe RelocType

--- a/src/Grease/Macaw/Arch/PPC32.hs
+++ b/src/Grease/Macaw/Arch/PPC32.hs
@@ -48,7 +48,7 @@ import qualified Stubs.Memory.PPC.Linux as Stubs
 import qualified Stubs.Syscall.PPC.Linux as Stubs
 import qualified Stubs.Syscall.Names.PPC32.Linux as Stubs
 
-import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRepr(PPC32Repr))
+import Grease.Macaw.Arch (ArchContext(..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType(..))
 import Grease.Macaw.RegName (RegName(..))
 import Grease.Options (ExtraStackSlots)
@@ -84,8 +84,7 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
             Map.empty
   return
     ArchContext
-      { _archRepr = PPC32Repr
-      , _archInfo = PPC.ppc32_linux_info
+      { _archInfo = PPC.ppc32_linux_info
       , _archEndianness = Mem.BigEndian
       , _archGetIP = \regs -> do
           C.RV (Mem.LLVMPointer _base off) <- PPC.Symbolic.Regs.lookupReg PPC.PPC_IP regs

--- a/src/Grease/Macaw/Arch/PPC64.hs
+++ b/src/Grease/Macaw/Arch/PPC64.hs
@@ -51,7 +51,7 @@ import qualified Stubs.Memory.PPC.Linux as Stubs
 import qualified Stubs.Syscall.PPC.Linux as Stubs
 import qualified Stubs.Syscall.Names.PPC64.Linux as Stubs
 
-import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRepr(PPC64Repr))
+import Grease.Macaw.Arch (ArchContext(..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType(..))
 import Grease.Macaw.RegName (RegName(..))
 import Grease.Options (ExtraStackSlots)
@@ -93,8 +93,7 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
             Map.empty
   return
     ArchContext
-      { _archRepr = PPC64Repr
-      , _archInfo = PPC.ppc64_linux_info loadedBinary
+      { _archInfo = PPC.ppc64_linux_info loadedBinary
       , _archEndianness = Mem.BigEndian
       , _archGetIP = \regs -> do
           C.RV (Mem.LLVMPointer _base off) <- PPC.Symbolic.Regs.lookupReg PPC.PPC_IP regs

--- a/src/Grease/Macaw/Arch/PPC64.hs
+++ b/src/Grease/Macaw/Arch/PPC64.hs
@@ -114,6 +114,7 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
       , _archStackPtrShape = ppcStackPtrShape (bytes64LE <$> mbReturnAddr) stackArgSlots
       , _archInitGlobals = \_ mem -> pure (mem, C.emptyGlobals)
       , _archRegOverrides = regOverrides
+      , _archOffsetStackPointerPostCall = pure
       }
 
 ppc64RelocSupported :: EE.PPC64_RelocationType -> Maybe RelocType

--- a/src/Grease/Macaw/Arch/X86.hs
+++ b/src/Grease/Macaw/Arch/X86.hs
@@ -51,7 +51,7 @@ import qualified Stubs.Syscall.Names.X86_64.Linux as Stubs
 -- what4
 import qualified What4.Interface as W4
 
-import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRegs, ArchRepr(X86Repr))
+import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRegs)
 import Grease.Macaw.Arch.X86.Reg (getX86Reg, modifyX86Reg)
 import Grease.Macaw.Load.Relocation (RelocType(..))
 import Grease.Options (ExtraStackSlots)
@@ -84,8 +84,7 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
     Just avals -> pure avals
   return
     ArchContext
-      { _archRepr = X86Repr
-      , _archInfo = X86.x86_64_linux_info
+      { _archInfo = X86.x86_64_linux_info
       , _archEndianness = Mem.LittleEndian
       , _archVals = avals
       , _archRelocSupported = x64RelocSupported

--- a/src/Grease/Macaw/Arch/X86.hs
+++ b/src/Grease/Macaw/Arch/X86.hs
@@ -12,13 +12,18 @@ Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Macaw.Arch.X86 (x86Ctx) where
 
 import Control.Exception.Safe (throw)
+import Control.Monad.IO.Class (MonadIO(..))
 import qualified Data.Map as Map
 import Data.Proxy (Proxy(..))
 import Data.Word (Word64)
 
+-- bv-sized
+import qualified Data.BitVector.Sized as BV
+
 -- crucible
+import qualified Lang.Crucible.Backend as C
 import qualified Lang.Crucible.FunctionHandle as C
-import qualified Lang.Crucible.Simulator.RegValue as C
+import qualified Lang.Crucible.Simulator as C
 
 -- crucible-llvm
 import qualified Lang.Crucible.LLVM.MemModel as Mem
@@ -32,6 +37,10 @@ import qualified Data.Macaw.Symbolic as Symbolic
 
 -- macaw-x86
 import qualified Data.Macaw.X86 as X86
+import qualified Data.Macaw.X86.X86Reg as X86
+
+-- parameterized-utils
+import qualified Data.Parameterized.NatRepr as NatRepr
 
 -- stubs
 import qualified Stubs.FunctionOverride.X86_64.Linux as Stubs
@@ -39,8 +48,11 @@ import qualified Stubs.Memory.X86_64.Linux as Stubs
 import qualified Stubs.Syscall.X86_64.Linux as Stubs
 import qualified Stubs.Syscall.Names.X86_64.Linux as Stubs
 
-import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRepr(X86Repr))
-import Grease.Macaw.Arch.X86.Reg (getX86Reg)
+-- what4
+import qualified What4.Interface as W4
+
+import Grease.Macaw.Arch (ArchContext(..), ArchReloc, ArchRegs, ArchRepr(X86Repr))
+import Grease.Macaw.Arch.X86.Reg (getX86Reg, modifyX86Reg)
 import Grease.Macaw.Load.Relocation (RelocType(..))
 import Grease.Options (ExtraStackSlots)
 import Grease.Shape.Pointer (x64StackPtrShape)
@@ -95,9 +107,25 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
          -- NB: x86-64 does not have a link register, so we don't need to
          -- override it.
       , _archRegOverrides = Map.empty
+      , _archOffsetStackPointerPostCall = x64FixupStackPointer
       }
 
 x64RelocSupported :: EE.X86_64_RelocationType -> Maybe RelocType
 x64RelocSupported EE.R_X86_64_RELATIVE = Just RelativeReloc
 x64RelocSupported EE.R_X86_64_GLOB_DAT = Just SymbolReloc
 x64RelocSupported _ = Nothing
+
+-- | On x86, the @call@ instruction pushes the return address onto the stack.
+-- When skipping a function or using an override, no @ret@ instruction will
+-- pop the return address (and increment the stack pointer accordingly), so we
+-- simulate that effect here.
+x64FixupStackPointer ::
+  C.IsSymInterface sym =>
+  ArchRegs sym X86.X86_64 ->
+  C.OverrideSim p sym ext rtp a r (ArchRegs sym X86.X86_64)
+x64FixupStackPointer regs = do
+  sym <- C.getSymInterface
+  modifyX86Reg regs X86.RSP $ \(C.RV rsp) -> liftIO $ do
+    let widthRepr = NatRepr.knownNat @64
+    eight <- W4.bvLit sym widthRepr (BV.mkBV widthRepr 8)
+    C.RV <$> Mem.ptrAdd sym widthRepr rsp eight


### PR DESCRIPTION
`fixupStackPointer` does something different depending on the architecure, so it really ought to be a field of `ArchContext`. This PR makes it so, under the new name `archOffsetStackPointerPostCall` (to make it more obvious under what circumstances this should be used).

`fixupStackPointer` was the only function that pattern-matched on `ArchRepr` values, so this PR also removes `ArchRepr`. Doing so will make it easier to split `grease` into architecture-specific libraries in the future.

Progress towards #46.