### PR TITLE
Support more `SymbolReloc`s (e.g., `R_X86_64_64`)

### DIFF
--- a/src/Grease/Macaw/Arch.hs
+++ b/src/Grease/Macaw/Arch.hs
@@ -20,7 +20,6 @@ module Grease.Macaw.Arch
   , archPcReg
   , archVals
   , archRelocSupported
-  , archIsGlobDatReloc
   , archIntegerArguments
   , archIntegerReturnRegisters
   , archFunctionReturnAddr
@@ -119,8 +118,6 @@ data ArchContext arch = ArchContext
     -- Check if @grease@ supports a particular relocation type. This should
     -- return 'Nothing' if it is unsupported and 'Just' if it is supported.
   , _archRelocSupported :: ArchReloc arch -> Maybe RelocType
-  , -- Check if a relocation type is @GLOB_DAT@.
-    _archIsGlobDatReloc :: ArchReloc arch -> Bool
   , -- Given a full register state, extract all of the arguments we need for the
     -- function call.
     _archIntegerArguments ::

--- a/src/Grease/Macaw/Arch/AArch32.hs
+++ b/src/Grease/Macaw/Arch/AArch32.hs
@@ -90,7 +90,6 @@ armCtx halloc mbReturnAddr stackArgSlots = do
       , _archPcReg = ARM.pc
       , _archVals = avals
       , _archRelocSupported = armRelocSupported
-      , _archIsGlobDatReloc = (== EE.R_ARM_GLOB_DAT)
       , _archIntegerArguments = \bak ->
           Stubs.aarch32LinuxIntegerArguments bak avals
       , _archIntegerReturnRegisters = Stubs.aarch32LinuxIntegerReturnRegisters
@@ -108,4 +107,5 @@ armCtx halloc mbReturnAddr stackArgSlots = do
 armRelocSupported :: EE.ARM32_RelocationType -> Maybe RelocType
 armRelocSupported EE.R_ARM_RELATIVE = Just RelativeReloc
 armRelocSupported EE.R_ARM_GLOB_DAT = Just SymbolReloc
+armRelocSupported EE.R_ARM_ABS32 = Just SymbolReloc
 armRelocSupported _ = Nothing

--- a/src/Grease/Macaw/Arch/PPC32.hs
+++ b/src/Grease/Macaw/Arch/PPC32.hs
@@ -92,7 +92,6 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
       , _archPcReg = PPC.PPC_IP
       , _archVals = avals
       , _archRelocSupported = ppc32RelocSupported
-      , _archIsGlobDatReloc = (== EE.R_PPC_GLOB_DAT)
       , _archIntegerArguments = \bak ->
           Stubs.ppcLinuxIntegerArguments bak avals
       , _archIntegerReturnRegisters = Stubs.ppcLinuxIntegerReturnRegisters
@@ -110,4 +109,5 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
 ppc32RelocSupported :: EE.PPC32_RelocationType -> Maybe RelocType
 ppc32RelocSupported EE.R_PPC_RELATIVE = Just RelativeReloc
 ppc32RelocSupported EE.R_PPC_GLOB_DAT = Just SymbolReloc
+ppc32RelocSupported EE.R_PPC_ADDR32 = Just SymbolReloc
 ppc32RelocSupported _ = Nothing

--- a/src/Grease/Macaw/Arch/PPC64.hs
+++ b/src/Grease/Macaw/Arch/PPC64.hs
@@ -101,7 +101,6 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
       , _archPcReg = PPC.PPC_IP
       , _archVals = avals
       , _archRelocSupported = ppc64RelocSupported
-      , _archIsGlobDatReloc = (== EE.R_PPC64_GLOB_DAT)
       , _archIntegerArguments = \bak ->
           Stubs.ppcLinuxIntegerArguments bak avals
       , _archIntegerReturnRegisters = Stubs.ppcLinuxIntegerReturnRegisters
@@ -119,4 +118,5 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
 ppc64RelocSupported :: EE.PPC64_RelocationType -> Maybe RelocType
 ppc64RelocSupported EE.R_PPC64_RELATIVE = Just RelativeReloc
 ppc64RelocSupported EE.R_PPC64_GLOB_DAT = Just SymbolReloc
+ppc64RelocSupported EE.R_PPC64_ADDR64 = Just SymbolReloc
 ppc64RelocSupported _ = Nothing

--- a/src/Grease/Macaw/Arch/X86.hs
+++ b/src/Grease/Macaw/Arch/X86.hs
@@ -88,7 +88,6 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
       , _archEndianness = Mem.LittleEndian
       , _archVals = avals
       , _archRelocSupported = x64RelocSupported
-      , _archIsGlobDatReloc = (== EE.R_X86_64_GLOB_DAT)
       , _archGetIP = \regs -> do
           C.RV (Mem.LLVMPointer _base off) <- getX86Reg X86.X86_IP regs
           pure off
@@ -112,6 +111,7 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
 x64RelocSupported :: EE.X86_64_RelocationType -> Maybe RelocType
 x64RelocSupported EE.R_X86_64_RELATIVE = Just RelativeReloc
 x64RelocSupported EE.R_X86_64_GLOB_DAT = Just SymbolReloc
+x64RelocSupported EE.R_X86_64_64 = Just SymbolReloc
 x64RelocSupported _ = Nothing
 
 -- | On x86, the @call@ instruction pushes the return address onto the stack.

--- a/src/Grease/Macaw/Load/Relocation.hs
+++ b/src/Grease/Macaw/Load/Relocation.hs
@@ -14,6 +14,7 @@ module Grease.Macaw.Load.Relocation
 import Control.Exception (throw)
 import qualified Data.ByteString as BS
 import Data.Either (Either(..), either)
+import Data.Eq (Eq)
 import Data.Function (($), const)
 import Data.List (map)
 import qualified Data.Map.Strict as Map
@@ -43,6 +44,7 @@ data RelocType
     -- These include absolute references to symbols in the same shared library
     -- (e.g., @R_ARM_ABS32@) and global variables defined in separate shared
     -- libraries (e.g., @R_ARM_GLOB_DAT@).
+  deriving Eq
 
 -- | Read the @.rela.dyn@ and @.rel.dyn@ sections of an ELF binary (if they
 -- exist) to construct a map of dynamic relocation addresses to their

--- a/src/Grease/Macaw/PLT.hs
+++ b/src/Grease/Macaw/PLT.hs
@@ -296,11 +296,22 @@ other than relying on PLT stubs.
 We work around both issues using the same solution. Both .plt.got stubs and
 inlined code arising from -fno-plt share the characteristic that the
 corresponding entries in the GOT contain GLOB_DAT relocations, which identify
-the symbol of the external function. Therefore, if we are about to call into
-an address that corresponds to a GLOB_DAT relocation, then we assume that the
-GLOB_DAT's symbol is an external function. This is an over-approximation, as
-GLOB_DAT relocations can refer to things besides functions (e.g., global
-variables), but this over-approximation is unlikely to cause any harm.
+the symbol of the external function.
+
+Normally, the memory that a GLOB_DAT relocation's address points to would not
+be known statically, as this is information that would be determined at dynamic
+load time. For simulation purposes, however, we can employ a simple hack: we
+pretend that this memory contains the address of the relocation itself. The
+relocation address is a reasonably unique identifier that we can use to
+determine if we are about to call into the function corresponding the the
+GLOB_DAT relocation. (See Grease.Macaw.globalMemoryHooks for where this hack is
+implemented.)
+
+Therefore, if we are about to call into an address that corresponds to a
+GLOB_DAT relocation, then we assume that the GLOB_DAT's symbol is an external
+function. This is an over-approximation, as GLOB_DAT relocations can refer to
+things besides functions (e.g., global variables), but this over-approximation
+is unlikely to cause any harm.
 
 In the event that this workaround isn't enough, we also provide a --plt-stub
 command-line flag that allows users to specify the names and addresses of


### PR DESCRIPTION
In addition to `GLOB_DAT` relocs, all of our supported architectures contain at least one other symbol-related relocation (e.g., `R_X86_64_64` on x86-64). What's more, some programs may actually call into these relocations directly under certain circumstances, such as in this program:

```c

struct foo {
  void* (*my_malloc)(size_t);
  void (*my_free)(void*);
};

static struct foo f = { malloc, free };

int main(void) {
  int* x = f.my_malloc(sizeof(int));
  *x = 0;
  int y = *x;
  f.my_free(x);
  return y;
}
```

(Annoyingly, the `musl`-based compiled that the test suite's Nix flake provides do not exhibit the same behavior, so it is difficult to add a test case for this property.)

This patch adds `R_X86_64_64` _et al._ as `SymbolReloc`s such that `grease` will be able to characterize them as external function calls when necessary. As a result, this patch resolves one part of https://github.com/GaloisInc/grease/issues/22.