### PR TITLE
`initState`: Accept arbitrary `SymGlobalState`

### DIFF
--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -679,7 +679,7 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook mbCfg
         -- use an empty map instead. (See gitlab#118 for more discussion on this point.)
         let discoveredHdls = Maybe.maybe Map.empty (`Map.singleton` ssaCfgHdl) mbCfgAddr
         let personality = emptyGreaseSimulatorState & discoveredFnHandles .~ discoveredHdls
-        initState bak la macawExtImpl halloc mvar mem' archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
+        initState bak la macawExtImpl halloc mvar mem' C.emptyGlobals archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
 
   doLog la (Diag.TargetCFG ssaCfg)
   result <- refinementLoop la (maxIters simOpts) (simTimeout simOpts) rNamesAssign' initArgs $ \argShapes -> do
@@ -1154,7 +1154,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
     let ?recordLLVMAnnotation = \callStack (Mem.BoolAnn ann) bb ->
           modifyIORef bbMapRef $ Map.insert ann (callStack, bb)
     let llvmExtImpl = CLLVM.llvmExtensionImpl ?memOpts
-    st <- LLVM.initState bak la llvmExtImpl halloc (simErrorSymbolicFunCalls simOpts) setupMem llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
+    st <- LLVM.initState bak la llvmExtImpl halloc (simErrorSymbolicFunCalls simOpts) setupMem C.emptyGlobals llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
     let cmdExt = Debug.llvmCommandExt
     debuggerFeat <-
       liftIO $

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
@@ -23,7 +23,6 @@ import qualified Data.BitVector.Sized as BV
 import Data.Parameterized.NatRepr (knownNat)
 
 -- crucible
-import qualified Lang.Crucible.Simulator.GlobalState as C
 import qualified Lang.Crucible.Simulator.RegValue as C
 
 -- crucible-llvm
@@ -101,7 +100,7 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
       , _archSyscallReturnRegisters = Stubs.ppcLinuxSyscallReturnRegisters PPC.V32Repr
       , _archSyscallCodeMapping = Stubs.syscallMap
       , _archStackPtrShape = ppcStackPtrShape (bytes32LE <$> mbReturnAddr) stackArgSlots
-      , _archInitGlobals = \_ mem -> pure (mem, C.emptyGlobals)
+      , _archInitGlobals = \_ mem globals -> pure (mem, globals)
       , _archRegOverrides = regOverrides
       , _archOffsetStackPointerPostCall = pure
       }

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
@@ -23,7 +23,6 @@ import qualified Data.BitVector.Sized as BV
 import Data.Parameterized.NatRepr (knownNat)
 
 -- crucible
-import qualified Lang.Crucible.Simulator.GlobalState as C
 import qualified Lang.Crucible.Simulator.RegValue as C
 
 -- crucible-llvm
@@ -110,7 +109,7 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
       , _archSyscallReturnRegisters = Stubs.ppcLinuxSyscallReturnRegisters PPC.V64Repr
       , _archSyscallCodeMapping = Stubs.syscallMap
       , _archStackPtrShape = ppcStackPtrShape (bytes64LE <$> mbReturnAddr) stackArgSlots
-      , _archInitGlobals = \_ mem -> pure (mem, C.emptyGlobals)
+      , _archInitGlobals = \_ mem globals -> pure (mem, globals)
       , _archRegOverrides = regOverrides
       , _archOffsetStackPointerPostCall = pure
       }

--- a/grease/src/Grease/LLVM.hs
+++ b/grease/src/Grease/LLVM.hs
@@ -79,6 +79,7 @@ initState ::
   C.HandleAllocator ->
   ErrorSymbolicFunCalls ->
   SetupMem sym ->
+  C.SymGlobalState sym ->
   Trans.LLVMContext arch ->
   SetupHook ->
   -- | The initial arguments to the entrypoint function.
@@ -88,7 +89,7 @@ initState ::
   -- | The CFG of the user-requested entrypoint function.
   C.SomeCFG LLVM argTys retTy ->
   m (C.ExecState () sym LLVM (C.RegEntry sym retTy))
-initState bak la llvmExtImpl halloc errorSymbolicFunCalls mem llvmCtx setupHook initArgs mbStartupOvCfg (C.SomeCFG cfg) = do
+initState bak la llvmExtImpl halloc errorSymbolicFunCalls mem globs llvmCtx setupHook initArgs mbStartupOvCfg (C.SomeCFG cfg) = do
   let dl = TCtx.llvmDataLayout (llvmCtx ^. Trans.llvmTypeCtx)
   let extImpl = greaseLlvmExtImpl la halloc dl errorSymbolicFunCalls llvmExtImpl
   let bindings = C.FnBindings
@@ -109,7 +110,7 @@ initState bak la llvmExtImpl halloc errorSymbolicFunCalls mem llvmCtx setupHook 
   let mvar = Trans.llvmMemVar llvmCtx
   pure $
     C.InitialState ctx
-      (C.insertGlobal mvar (getSetupMem mem) C.emptyGlobals)
+      (C.insertGlobal mvar (getSetupMem mem) globs)
       C.defaultAbortHandler
       (C.cfgReturnType cfg)
       (C.runOverrideSim (C.cfgReturnType cfg) $ do

--- a/grease/src/Grease/Macaw/Arch.hs
+++ b/grease/src/Grease/Macaw/Arch.hs
@@ -237,6 +237,7 @@ data ArchContext arch = ArchContext
       Mem.HasLLVMAnn sym =>
       Stubs.Sym sym ->
       Mem.MemImpl sym ->
+      C.SymGlobalState sym ->
       IO (Mem.MemImpl sym, C.SymGlobalState sym)
   , -- | When setting up the initial register values just before starting
     -- simulation, override the default values for the following registers and


### PR DESCRIPTION
This requires bumping the `stubs` submodule to bring in the changes from https://github.com/GaloisInc/stubs/pull/62, which are a prerequisite.

Fixes #72.

-----

Marking as a draft pending https://github.com/GaloisInc/stubs/pull/62 (on which this PR depends) landing upstream.