### PR TITLE
Remove special handling of command-line flags from the test suite

### DIFF
--- a/doc/dev.md
+++ b/doc/dev.md
@@ -146,18 +146,10 @@ To add a new test, add a new directory under the appropriate directory above. It
 - A 32-bit PowerPC ELF executable named `test.ppc32.elf`. (At the moment, we don't include 64-bit PowerPC executables, but we could if the need arose.)
 - An x86_64 executable named `test.x64.elf`.
 
-Each executable should contain an entrypoint symbol named `test`.
-
 By default, each test will be run as though `grease` were invoked with the
-following command-line options:
-
-* The entrypoint is set to `--symbol test`.
-* `--iters` is set to `128` to ensure that the `xfail-iters` tests
-  complete in a somewhat reasonable amount of time.
-* All other command-line options inherit their default values.
-
-If you wish to override these options, you can do so by adding a line that
-begins with `// flags: ` to the corresponding C program, like so:
+binary as its only argument. Tests may provide further command-line  flags by
+adding a line that begins with `// flags: ` to the corresponding C program,
+like so:
 
 ```c
 // flags: --symbol foo --stack-argument-slots 5
@@ -171,9 +163,13 @@ You can also add architecture-specific flags like so:
 // flags(x64): --address 0x401000
 ```
 
-All applicable comments will be combined into a single configuration. If a
-command-line option is not explicitly mentioned in a `flags` comment, then it
-will inherit its default value as described above.
+It is common (though not necessary) to define a function named `test` and to
+specify it as the only entrypoint:
+```c
+// flags: --symbol test
+
+void test(/* ... */) { /* ... */ }
+```
 
 ### LLVM bitcode and S-expression test cases
 

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -196,4 +196,13 @@ specially-formatted comments. For LLVM bitcode programs, add a line beginning
 with `// flags: ` to the corresponding C program. For S-expression programs, add
 a line beginning with `; flags: `.
 
+### Writing good tests
+
+The Rust Compiler Development Guide has some [helpful guidance] on writing
+high-quality tests. The GREASE test suite is generally quite similar in
+structure to that of rustc, so almost all of the advice there applies *mutatis
+mutandis*.
+
+[helpful guidance]: (https://github.com/rust-lang/rust/blob/3350c1eb3fd8fe1bee1ed4c76944d707bd256876/src/doc/rustc-dev-guide/src/tests/best-practices.md)
+
 <!-- Copyright (c) Galois, Inc. 2024. -->

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -147,7 +147,7 @@ To add a new test, add a new directory under the appropriate directory above. It
 - An x86_64 executable named `test.x64.elf`.
 
 By default, each test will be run as though `grease` were invoked with the
-binary as its only argument. Tests may provide further command-line  flags by
+binary as its only argument. Tests may provide further command-line flags by
 adding a line that begins with `// flags: ` to the corresponding C program,
 like so:
 

--- a/grease-cli/tests/arm/declare-in-override.armv7l.cbl
+++ b/grease-cli/tests/arm/declare-in-override.armv7l.cbl
@@ -3,6 +3,7 @@
 ; A test case that demonstrates that forward declarations can be used in both
 ; Macaw S-expression programs and their overrides (gitlab#159).
 
+; flags: --symbol test
 ; flags: --overrides tests/arm/extra/my-malloc.armv7l.cbl
 
 ; A forward declaration to a built-in override.

--- a/grease-cli/tests/arm/id.armv7l.cbl
+++ b/grease-cli/tests/arm/id.armv7l.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs AArch32Regs)) AArch32Regs
   (start start:
     (return regs)))

--- a/grease-cli/tests/arm/user-override.armv7l.cbl
+++ b/grease-cli/tests/arm/user-override.armv7l.cbl
@@ -1,5 +1,6 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
 ; flags: --overrides tests/arm/extra/id-ptr.armv7l.cbl
 
 (declare @id-ptr ((p (Ptr 32))) (Ptr 32))

--- a/grease-cli/tests/llvm-bc/declare-in-override.c
+++ b/grease-cli/tests/llvm-bc/declare-in-override.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --overrides tests/llvm-bc/extra/my_malloc.llvm.cbl
 
 #include <stdint.h>

--- a/grease-cli/tests/llvm-bc/load-handle.c
+++ b/grease-cli/tests/llvm-bc/load-handle.c
@@ -2,6 +2,7 @@
 
 // A regression test for gitlab#158.
 
+// flags: --symbol test
 // flags: --overrides tests/llvm-bc/extra/f.cbl
 
 void* f(void);

--- a/grease-cli/tests/llvm-bc/malloc-free-redefined.c
+++ b/grease-cli/tests/llvm-bc/malloc-free-redefined.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // A regression test for gitlab#156.
+
+// flags: --symbol test
+
 #include <stddef.h>
 
 void *malloc(size_t size) {

--- a/grease-cli/tests/llvm-bc/memset.c
+++ b/grease-cli/tests/llvm-bc/memset.c
@@ -3,6 +3,9 @@
 // Regression test for gitlab#170, test that "polymorphic" LLVM overrides such
 // as `memset` are properly handled; and for gitlab#186, test that the
 // heuristics handle `memset` by allocating enough space.
+
+// flags: --symbol test
+
 #include <string.h>
 
 void *test(void *dest) {

--- a/grease-cli/tests/llvm-bc/multiple-defines.c
+++ b/grease-cli/tests/llvm-bc/multiple-defines.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdlib.h>
 
 void panic(void) {

--- a/grease-cli/tests/llvm-bc/skip.c
+++ b/grease-cli/tests/llvm-bc/skip.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 extern int skippable(void);
 
 int test(void) {

--- a/grease-cli/tests/llvm/abort.llvm.cbl
+++ b/grease-cli/tests/llvm/abort.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let g (resolve-global "abort"))

--- a/grease-cli/tests/llvm/both-branches-abort.llvm.cbl
+++ b/grease-cli/tests/llvm/both-branches-abort.llvm.cbl
@@ -1,6 +1,8 @@
 ; This test-case branches on data in its arguments. In both branches, it calls
 ; `abort`. This pattern should be recognized by the "one must fail" heuristic.
 
+; flags: --symbol test
+
 (defun @test ((b Bool)) Unit
   (registers
     ($h (-> Unit)))

--- a/grease-cli/tests/llvm/declare-in-override.llvm.cbl
+++ b/grease-cli/tests/llvm/declare-in-override.llvm.cbl
@@ -3,6 +3,7 @@
 ; A test case that demonstrates that forward declarations can be used in both
 ; LLVM S-expression programs and their overrides (gitlab#159).
 
+; flags: --symbol test
 ; flags: --overrides tests/llvm/extra/my-malloc.llvm.cbl
 
 ; A forward declaration to a built-in override.

--- a/grease-cli/tests/llvm/double-free.llvm.cbl
+++ b/grease-cli/tests/llvm/double-free.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let g (resolve-global "free"))

--- a/grease-cli/tests/llvm/empty.llvm.cbl
+++ b/grease-cli/tests/llvm/empty.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (return ())))

--- a/grease-cli/tests/llvm/exit.llvm.cbl
+++ b/grease-cli/tests/llvm/exit.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let g (resolve-global "exit"))

--- a/grease-cli/tests/llvm/free-non-ptr.llvm.cbl
+++ b/grease-cli/tests/llvm/free-non-ptr.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let g (resolve-global "free"))

--- a/grease-cli/tests/llvm/free-stack.llvm.cbl
+++ b/grease-cli/tests/llvm/free-stack.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let sz (bv 64 1))

--- a/grease-cli/tests/llvm/free.llvm.cbl
+++ b/grease-cli/tests/llvm/free.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let g (resolve-global "free"))

--- a/grease-cli/tests/llvm/func-ptr-error.llvm.cbl
+++ b/grease-cli/tests/llvm/func-ptr-error.llvm.cbl
@@ -4,6 +4,7 @@
 ; --error-symbolic-fun-calls such that the call to a symbolic function handle
 ; should raise an error.
 
+; flags: --symbol test
 ; flags: --error-symbolic-fun-calls
 
 (defun @test ((p (Ptr 64))) Unit

--- a/grease-cli/tests/llvm/func-ptr.llvm.cbl
+++ b/grease-cli/tests/llvm/func-ptr.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
 ;; check "Skipped call to a symbolic function handle"

--- a/grease-cli/tests/llvm/id-bool.llvm.cbl
+++ b/grease-cli/tests/llvm/id-bool.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 ; This definition is used as an override in the user-override.llvm.cbl
 ; test case.
 (defun @id-bool ((b (Ptr 1))) (Ptr 1)

--- a/grease-cli/tests/llvm/load.llvm.cbl
+++ b/grease-cli/tests/llvm/load.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (load none i8 p)

--- a/grease-cli/tests/llvm/malloc.llvm.cbl
+++ b/grease-cli/tests/llvm/malloc.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let blk0 (the Nat 0))

--- a/grease-cli/tests/llvm/memcpy.llvm.cbl
+++ b/grease-cli/tests/llvm/memcpy.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((dst (Ptr 64)) (src (Ptr 64))) Unit
   (start start:
     (let g (resolve-global "memcpy"))

--- a/grease-cli/tests/llvm/memset-large-const-len.llvm.cbl
+++ b/grease-cli/tests/llvm/memset-large-const-len.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let g (resolve-global "memset"))

--- a/grease-cli/tests/llvm/memset.llvm.cbl
+++ b/grease-cli/tests/llvm/memset.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let g (resolve-global "memset"))

--- a/grease-cli/tests/llvm/null-read.llvm.cbl
+++ b/grease-cli/tests/llvm/null-read.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () (Ptr 8)
   (start start:
     (let p (ptr 64 0 (bv 64 0)))

--- a/grease-cli/tests/llvm/null-write.llvm.cbl
+++ b/grease-cli/tests/llvm/null-write.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test () Unit
   (start start:
     (let p (ptr 64 0 (bv 64 0)))

--- a/grease-cli/tests/llvm/ptr-add-large-offset.llvm.cbl
+++ b/grease-cli/tests/llvm/ptr-add-large-offset.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) (Ptr 64)
   (start start:
     (let kb (bv 64 4096))

--- a/grease-cli/tests/llvm/ptr-add-offset.llvm.cbl
+++ b/grease-cli/tests/llvm/ptr-add-offset.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) (Ptr 64)
   (start start:
     (let one (bv 64 1))

--- a/grease-cli/tests/llvm/rust-enum.llvm.cbl
+++ b/grease-cli/tests/llvm/rust-enum.llvm.cbl
@@ -5,6 +5,7 @@
 ; that we can load from uninitialized memory without crashing when the --rust
 ; flags is enabled.
 
+; flags: --symbol test
 ; flags: --rust
 
 (defun @test () Unit

--- a/grease-cli/tests/llvm/skip-ptr.llvm.cbl
+++ b/grease-cli/tests/llvm/skip-ptr.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (declare @skippable () (Ptr 64))
 (defun @test () (Ptr 64)
   (start start:

--- a/grease-cli/tests/llvm/skip-void.llvm.cbl
+++ b/grease-cli/tests/llvm/skip-void.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (declare @skippable () Unit)
 (defun @test ((b (Ptr 1))) (Ptr 1)
   (start start:

--- a/grease-cli/tests/llvm/store.llvm.cbl
+++ b/grease-cli/tests/llvm/store.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let blk (the Nat 0))

--- a/grease-cli/tests/llvm/struct-override-caller.llvm.cbl
+++ b/grease-cli/tests/llvm/struct-override-caller.llvm.cbl
@@ -2,6 +2,7 @@
 
 ; A regression test for gitlab#157.
 
+; flags: --symbol test
 ; flags: --overrides tests/llvm/extra/struct-override-callee.llvm.cbl
 
 (declare @struct-override-callee () (Struct (Bitvector 32) (Bitvector 64)))

--- a/grease-cli/tests/llvm/trap.llvm.cbl
+++ b/grease-cli/tests/llvm/trap.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 ; Ensure that GREASE properly overrides `llvm.trap`, causing inference failure.
 ; If it were instead skipped, then inference would succeed.
 (defun @test ((p (Ptr 64))) Unit

--- a/grease-cli/tests/llvm/uninit-stack.llvm.cbl
+++ b/grease-cli/tests/llvm/uninit-stack.llvm.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((p (Ptr 64))) Unit
   (start start:
     (let sz (bv 64 1))
@@ -7,6 +9,6 @@
     (load none i8 a)
     (return ())))
 ;; check [[
-;; Likely bug: uninitialized stack read at tests/llvm/uninit-stack.llvm.cbl:7:5
-;; Allocated at tests/llvm/uninit-stack.llvm.cbl:6:12
+;; Likely bug: uninitialized stack read at tests/llvm/uninit-stack.llvm.cbl:9:5
+;; Allocated at tests/llvm/uninit-stack.llvm.cbl:8:12
 ;; ]]

--- a/grease-cli/tests/llvm/user-override-defun.llvm.cbl
+++ b/grease-cli/tests/llvm/user-override-defun.llvm.cbl
@@ -3,6 +3,7 @@
 ; A variant of user-override.llvm.cbl where @id-bool is defun'd rather than
 ; declare'd. This serves as a regression test for gitlab#156.
 
+; flags: --symbol test
 ; flags: --overrides tests/llvm/id-bool.llvm.cbl
 
 (defun @id-bool ((b (Ptr 1))) (Ptr 1)

--- a/grease-cli/tests/llvm/user-override.llvm.cbl
+++ b/grease-cli/tests/llvm/user-override.llvm.cbl
@@ -1,5 +1,6 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
 ; flags: --overrides tests/llvm/id-bool.llvm.cbl
 
 (declare @id-bool ((p (Ptr 1))) (Ptr 1))

--- a/grease-cli/tests/ppc32/declare-in-override.ppc32.cbl
+++ b/grease-cli/tests/ppc32/declare-in-override.ppc32.cbl
@@ -3,6 +3,7 @@
 ; A test case that demonstrates that forward declarations can be used in both
 ; Macaw S-expression programs and their overrides (gitlab#159).
 
+; flags: --symbol test
 ; flags: --overrides tests/ppc32/extra/my-malloc.ppc32.cbl
 
 ; A forward declaration to a built-in override.

--- a/grease-cli/tests/ppc32/id.ppc32.cbl
+++ b/grease-cli/tests/ppc32/id.ppc32.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs PPC32Regs)) PPC32Regs
   (start start:
     (return regs)))

--- a/grease-cli/tests/ppc32/pos-stack-offset-read.ppc32.cbl
+++ b/grease-cli/tests/ppc32/pos-stack-offset-read.ppc32.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs PPC32Regs)) PPC32Regs
   (start start:
     (let p (get-reg r1 regs))  ;; r1, stack pointer

--- a/grease-cli/tests/ppc32/pos-stack-offset-write.ppc32.cbl
+++ b/grease-cli/tests/ppc32/pos-stack-offset-write.ppc32.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs PPC32Regs)) PPC32Regs
   (start start:
     (let p (get-reg r1 regs))  ;; r1, stack pointer

--- a/grease-cli/tests/ppc32/user-override.ppc32.cbl
+++ b/grease-cli/tests/ppc32/user-override.ppc32.cbl
@@ -1,5 +1,6 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
 ; flags: --overrides tests/ppc32/extra/id-ptr.ppc32.cbl
 
 (declare @id-ptr ((p (Ptr 32))) (Ptr 32))

--- a/grease-cli/tests/prop/in-text/neg/simple/test.c
+++ b/grease-cli/tests/prop/in-text/neg/simple/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --req in-text
 
 int __attribute__((noinline)) inc(int x) { return x + 1; }

--- a/grease-cli/tests/prop/in-text/pos/data/test.c
+++ b/grease-cli/tests/prop/in-text/pos/data/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --req in-text
 
 __attribute__((section(".data"))) int inc(int x) { return x + 1; }

--- a/grease-cli/tests/prop/in-text/pos/data_if/test.c
+++ b/grease-cli/tests/prop/in-text/pos/data_if/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --req in-text
 
 __attribute__((section(".data"))) int inc(int x) { return x + 1; }

--- a/grease-cli/tests/prop/in-text/pos/func_ptr/test.c
+++ b/grease-cli/tests/prop/in-text/pos/func_ptr/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --req in-text
 
 // The correct precondition for this function is complex... Not clear if it's

--- a/grease-cli/tests/prop/no-mprotect/pos/mprotect/test.c
+++ b/grease-cli/tests/prop/no-mprotect/pos/mprotect/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --req no-mprotect
 // flags(ppc32): --plt-stub 0x10000230:mprotect
 

--- a/grease-cli/tests/refine/bug/abort_before_trap/test.c
+++ b/grease-cli/tests/refine/bug/abort_before_trap/test.c
@@ -8,6 +8,9 @@
 // an error just before a trap, and we'd still like to report that error to the
 // user. As such, we want to ensure that the call to `abort` in this program
 // occurs without being superseded by the `ud2` instruction.
+
+// flags: --symbol test
+
 void abort(void) {}
 
 void panic(void) {

--- a/grease-cli/tests/refine/bug/abs_addr/test.c
+++ b/grease-cli/tests/refine/bug/abs_addr/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 int __attribute__((noinline)) deref(int *p) { return *p; }
 
 int test(void) { return deref((int *)(void *)0xdeadbeef); }

--- a/grease-cli/tests/refine/bug/assert_false/test.c
+++ b/grease-cli/tests/refine/bug/assert_false/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <assert.h>
 #include <stdbool.h>
 void test() { assert(false); }

--- a/grease-cli/tests/refine/bug/exit/test.c
+++ b/grease-cli/tests/refine/bug/exit/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdlib.h>
 void test(void) { exit(EXIT_FAILURE); }
 // all: must_fail()

--- a/grease-cli/tests/refine/bug/func_ptr_error/test.c
+++ b/grease-cli/tests/refine/bug/func_ptr_error/test.c
@@ -4,6 +4,7 @@
 // grease is invoked with --error-symbolic-fun-calls, which causes grease to
 // interpret the call to the symbolif function pointer as a bug.
 
+// flags: --symbol test
 // flags: --error-symbolic-fun-calls
 
 int test(int (*fun_ptr)()) { return fun_ptr(); }

--- a/grease-cli/tests/refine/bug/null_ptr_deref_pie/test.c
+++ b/grease-cli/tests/refine/bug/null_ptr_deref_pie/test.c
@@ -6,6 +6,8 @@
 // must load the memory at address 0x0 to virtual addresses with a constant
 // offset to ensure that the two do not overlap in the virtual address space.
 
+// flags: --symbol test
+
 __attribute__((noinline)) int f(int *in) { return *in; }
 
 int test(void) {

--- a/grease-cli/tests/refine/bug/oob_read_stack/test.c
+++ b/grease-cli/tests/refine/bug/oob_read_stack/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 __attribute__((noinline)) int dereferences_argument_16(int *ptr) {
   return ptr[16];
 }

--- a/grease-cli/tests/refine/bug/symbolic_ip/test.c
+++ b/grease-cli/tests/refine/bug/symbolic_ip/test.c
@@ -4,6 +4,9 @@
 // of g's definition will be stored in the global address space, which will
 // appear (at first glance) as a symbolic address. We must consult an SMT
 // solver to conclude that the address is in fact concrete.
+
+// flags: --symbol test
+
 #include <stdbool.h>
 
 void f(void) {

--- a/grease-cli/tests/refine/bug/uninit_stack_array_use/test.c
+++ b/grease-cli/tests/refine/bug/uninit_stack_array_use/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdlib.h>
 #include <time.h>
 

--- a/grease-cli/tests/refine/bug/uninit_stack_conditional/test.c
+++ b/grease-cli/tests/refine/bug/uninit_stack_conditional/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/grease-cli/tests/refine/bug/uninit_stack_var_use/test.c
+++ b/grease-cli/tests/refine/bug/uninit_stack_var_use/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdlib.h>
 #include <time.h>
 

--- a/grease-cli/tests/refine/bug/write_to_null/test.c
+++ b/grease-cli/tests/refine/bug/write_to_null/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 __attribute__((noinline)) void make_it_five(int *ptr) { *ptr = 5; }
 void test() { make_it_five(0); }
 // all: must_fail()

--- a/grease-cli/tests/refine/neg/abs_addr_if/test.c
+++ b/grease-cli/tests/refine/neg/abs_addr_if/test.c
@@ -2,6 +2,8 @@
 
 // This is a regression test for gitlab#239
 
+// flags: --symbol test
+
 int __attribute__((noinline)) deref(int *p) { return *p; }
 
 int test(int x) {

--- a/grease-cli/tests/refine/neg/factorial/test.c
+++ b/grease-cli/tests/refine/neg/factorial/test.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // gitlab#47
+
+// flags: --symbol test
+
 unsigned int test(unsigned int x) {
   if (x == 0) {
     return 1;

--- a/grease-cli/tests/refine/neg/libpng-cve-2018-13785/test.c
+++ b/grease-cli/tests/refine/neg/libpng-cve-2018-13785/test.c
@@ -1,4 +1,7 @@
 /* Minimized version of pngrutil.c to show CVE-2018-13785 (div-by-zero) */
+
+// flags: --symbol test
+
 /*
  * COPYRIGHT NOTICE, DISCLAIMER, and LICENSE:
  *

--- a/grease-cli/tests/refine/neg/loop/test.c
+++ b/grease-cli/tests/refine/neg/loop/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 // Test that there are some default loop bounds that prevent this from spinning
 unsigned int test(unsigned int n) {
   unsigned int sum = 0;

--- a/grease-cli/tests/refine/neg/read_null_global_pointer/test.c
+++ b/grease-cli/tests/refine/neg/read_null_global_pointer/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 int *glob = 0;
 int test() { return *glob; }
 // all: could_not_infer()

--- a/grease-cli/tests/refine/neg/write_const_global/test.c
+++ b/grease-cli/tests/refine/neg/write_const_global/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 const int x = 4;
 __attribute__((noinline)) void make_it_five(int *ptr) { *ptr = 5; }
 int test(int y) {

--- a/grease-cli/tests/refine/pos/cast_int_to_pointer_dereference/test.c
+++ b/grease-cli/tests/refine/pos/cast_int_to_pointer_dereference/test.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // Should behave the same as just having a pointer parameter
+
+// flags: --symbol test
+
 #include <stdint.h>
 int test(uintptr_t ptr) { return *((int *)(void *)ptr); }
 // all: ok()

--- a/grease-cli/tests/refine/pos/compare_ptrs_different_stack_allocs/test.c
+++ b/grease-cli/tests/refine/pos/compare_ptrs_different_stack_allocs/test.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // This is undefined behavior at the source level, but is fine in a binary
+
+// flags: --symbol test
+
 #include <stddef.h>
 
 __attribute__((noinline)) long compare(long x, long y) { return x < y; }

--- a/grease-cli/tests/refine/pos/compare_to_null/test.c
+++ b/grease-cli/tests/refine/pos/compare_to_null/test.c
@@ -1,4 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 int test(int *ptr) { return ptr == 0; }
 // all: ok()

--- a/grease-cli/tests/refine/pos/deref_arg_const_index/test.c
+++ b/grease-cli/tests/refine/pos/deref_arg_const_index/test.c
@@ -1,5 +1,8 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // Should be easy to deduce the precondition for this function
+
+// flags: --symbol test
+
 int test(int *ptr) { return ptr[8]; }
 // all: ok()

--- a/grease-cli/tests/refine/pos/deref_struct_field/test.c
+++ b/grease-cli/tests/refine/pos/deref_struct_field/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 typedef struct point {
   int x;
   int y;

--- a/grease-cli/tests/refine/pos/div/test.c
+++ b/grease-cli/tests/refine/pos/div/test.c
@@ -6,6 +6,9 @@
 // occur when invoking `foo`, this should not happen when analyzing `test` as an
 // entrypoint, as the concrete arguments it passes to `foo` should avoid any
 // code paths that would use `free` on `p` twice.
+
+// flags: --symbol test
+
 #include <stddef.h>
 
 // Redefine `malloc` and `free`. We won't actually use these implementations

--- a/grease-cli/tests/refine/pos/excluded_overrides/test.c
+++ b/grease-cli/tests/refine/pos/excluded_overrides/test.c
@@ -4,6 +4,7 @@
 // overrides to Macaw overrides that do not work well with macaw-symbolic's
 // lazy memory model.
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x10000300:putchar --plt-stub 0x10000310:puts --plt-stub 0x10000320:__assert_fail
 
 #include <assert.h>

--- a/grease-cli/tests/refine/pos/getppid_syscall_override/test.c
+++ b/grease-cli/tests/refine/pos/getppid_syscall_override/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <sys/syscall.h>
 #include <unistd.h>
 

--- a/grease-cli/tests/refine/pos/inc_ptr/test.c
+++ b/grease-cli/tests/refine/pos/inc_ptr/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 int inc(int x) { return x + 1; }
 
 int test(int *x) { return inc(*x); }

--- a/grease-cli/tests/refine/pos/inc_two_ptrs/test.c
+++ b/grease-cli/tests/refine/pos/inc_two_ptrs/test.c
@@ -2,6 +2,8 @@
 
 // Test multiple arguments
 
+// flags: --symbol test
+
 int inc(int x) { return x + 1; }
 
 int test(int *x, int *y) { return inc(*x) + inc(*y); }

--- a/grease-cli/tests/refine/pos/malloc-free-external/test.c
+++ b/grease-cli/tests/refine/pos/malloc-free-external/test.c
@@ -1,15 +1,16 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
-#include <stddef.h>
-#include <stdlib.h>
-
 // A variant of the malloc-free test case that dynamically links against libc
 // instead of redefining malloc and free. This ensures that the calls to malloc
 // and free come from an external shared library, which requires a different
 // code path for function overrides that overriding functions defined in the
 // same binary.
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x10000260:malloc --plt-stub 0x10000270:free
+
+#include <stddef.h>
+#include <stdlib.h>
 
 int test(void) {
   int* p = malloc(sizeof(int));

--- a/grease-cli/tests/refine/pos/malloc-free/test.c
+++ b/grease-cli/tests/refine/pos/malloc-free/test.c
@@ -1,10 +1,13 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
-#include <stddef.h>
-
 // A basic test that ensures the malloc and free overrides work as expected.
 // The implementations of malloc and free below don't matter, since they will
 // ultimately be overridden.
+
+// flags: --symbol test
+
+#include <stddef.h>
+
 void* malloc(size_t size) {
   return 0;
 }

--- a/grease-cli/tests/refine/pos/malloc/test.c
+++ b/grease-cli/tests/refine/pos/malloc/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x10000220:malloc
 
 #include <stdlib.h>

--- a/grease-cli/tests/refine/pos/pie/test.c
+++ b/grease-cli/tests/refine/pos/pie/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x270:malloc --plt-stub 0x280:free
 
 #include <stdlib.h>

--- a/grease-cli/tests/refine/pos/pointer_add/test.c
+++ b/grease-cli/tests/refine/pos/pointer_add/test.c
@@ -5,6 +5,8 @@
 // addition below (which macaw-symbolic interprets as a PtrAdd statement)
 // should not fail.
 
+// flags: --symbol test
+
 unsigned int test(unsigned int a, unsigned int b) {
   return a + b;
 }

--- a/grease-cli/tests/refine/pos/printf/test.c
+++ b/grease-cli/tests/refine/pos/printf/test.c
@@ -5,6 +5,7 @@
 // not register a built-in override for `printf` at all, instead skipping any
 // calls to `printf` during simulation.
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x10000220:printf
 
 #include <stdio.h>

--- a/grease-cli/tests/refine/pos/ptr_ptr/test.c
+++ b/grease-cli/tests/refine/pos/ptr_ptr/test.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // gitlab#38
+
+// flags: --symbol test
+
 int inc(int x) { return x + 1; }
 int test(int **x) { return inc(**x); }
 // all: ok()

--- a/grease-cli/tests/refine/pos/read_global/test.c
+++ b/grease-cli/tests/refine/pos/read_global/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 int glob = 4;
 int test() { return glob; }
 // all: ok()

--- a/grease-cli/tests/refine/pos/signed_add_wrap_concrete/test.c
+++ b/grease-cli/tests/refine/pos/signed_add_wrap_concrete/test.c
@@ -1,6 +1,9 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
 // UB at the source level; no problem at the binary level.
+
+// flags: --symbol test
+
 __attribute__((noinline)) int add_max_int_minus_one(int x) {
   return x + 2147483646; // 2^32 - 2
 }

--- a/grease-cli/tests/refine/pos/stack_protector/test.c
+++ b/grease-cli/tests/refine/pos/stack_protector/test.c
@@ -11,6 +11,8 @@
 // this program with -static.) We do not support these checks in PowerPC at all
 // at the moment.
 
+// flags: --symbol test
+
 int test(void) {
   return 0;
 }

--- a/grease-cli/tests/refine/pos/stack_spilled_arguments/test.c
+++ b/grease-cli/tests/refine/pos/stack_spilled_arguments/test.c
@@ -7,6 +7,7 @@
 // uninitialized stack read errors, we need to use the --stack-argument-slots
 // command-line option.
 
+// flags: --symbol test
 // flags(arm): --stack-argument-slots 5
 // flags(ppc32): --stack-argument-slots 1
 // flags(x64): --stack-argument-slots 3

--- a/grease-cli/tests/refine/pos/user_override/test.c
+++ b/grease-cli/tests/refine/pos/user_override/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags: --overrides tests/refine/pos/user_override/shouldnt_loop.cbl
 
 void shouldnt_loop(void) {

--- a/grease-cli/tests/refine/pos/write_to_global/test.c
+++ b/grease-cli/tests/refine/pos/write_to_global/test.c
@@ -2,6 +2,8 @@
 
 // A regression test for gitlab#202.
 
+// flags: --symbol test
+
 int glob[128] = {0};
 
 void test(void) {

--- a/grease-cli/tests/refine/xfail-neg/constructor/test.c
+++ b/grease-cli/tests/refine/xfail-neg/constructor/test.c
@@ -3,6 +3,8 @@
 // grease does not (yet) execute functions marked `__attribute__
 // ((constructor))` before analysis.
 
+// flags: --symbol test
+
 int g = 0;
 int *g_ptr;
 

--- a/grease-cli/tests/refine/xfail-neg/deref_arg_arg_index/test.c
+++ b/grease-cli/tests/refine/xfail-neg/deref_arg_arg_index/test.c
@@ -2,6 +2,12 @@
 
 // grease does not yet support this kind of precondition that depends on a
 // relation between two arguments
+
+// flags: --symbol test
+
+// Set --iters low to keep this test fast
+// flags: --iters 8
+
 int test(int *ptr, unsigned int idx) { return ptr[idx]; }
 // arm: could_not_infer()
 // TODO(#47):

--- a/grease-cli/tests/refine/xfail-neg/uninit_stack_in_struct/test.c
+++ b/grease-cli/tests/refine/xfail-neg/uninit_stack_in_struct/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/grease-cli/tests/sanity/pass/declare-in-override/test.c
+++ b/grease-cli/tests/sanity/pass/declare-in-override/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags(arm): --overrides tests/sanity/pass/declare-in-override/my_malloc.aux.armv7l.cbl
 // flags(ppc32): --overrides tests/sanity/pass/declare-in-override/my_malloc.aux.ppc32.cbl
 // flags(x64): --overrides tests/sanity/pass/declare-in-override/my_malloc.aux.x86_64.cbl

--- a/grease-cli/tests/sanity/pass/simulate_from_shared_library/test.c
+++ b/grease-cli/tests/sanity/pass/simulate_from_shared_library/test.c
@@ -5,6 +5,8 @@
 // that grease can resolve PLT calls to functions that occur within the same
 // shared library.
 
+// flags: --symbol test
+
 int deref(int *x) { return *x; }
 // arm: check "Calling a PLT stub (deref)"
 // x64: check "Calling a PLT stub (deref)"

--- a/grease-cli/tests/sanity/pass/startup-override/test.c
+++ b/grease-cli/tests/sanity/pass/startup-override/test.c
@@ -1,5 +1,6 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
 // flags(arm): --symbol-startup-override test:tests/sanity/pass/startup-override/startup-override.aux.armv7l.cbl
 // flags(ppc32): --symbol-startup-override test:tests/sanity/pass/startup-override/startup-override.aux.ppc32.cbl
 // flags(x64): --symbol-startup-override test:tests/sanity/pass/startup-override/startup-override.aux.x86_64.cbl

--- a/grease-cli/tests/sanity/pass/syscall/test.c
+++ b/grease-cli/tests/sanity/pass/syscall/test.c
@@ -1,9 +1,12 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
-#include <unistd.h>
-
 // A simple test that does nothing but call alarm(), which performs a syscall.
 // Currently, GREASE will treat all syscalls as no-ops.
+
+// flags: --symbol test
+
+#include <unistd.h>
+
 void test(void) {
   alarm(0);
 }

--- a/grease-cli/tests/sanity/pass/tricky_plt_stub/test.c
+++ b/grease-cli/tests/sanity/pass/tricky_plt_stub/test.c
@@ -4,6 +4,7 @@
 // of a function pointer so that there will be a PLT stub for `malloc` in the
 // `.plt.got` section (at least, on x86-64).
 
+// flags: --symbol test
 // flags(ppc32): --plt-stub 0x310:malloc
 
 #include <stdlib.h>

--- a/grease-cli/tests/sanity/xfail-iters/large_offset/test.c
+++ b/grease-cli/tests/sanity/xfail-iters/large_offset/test.c
@@ -1,5 +1,10 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// flags: --symbol test
+
+// Set --iters low to keep this test fast
+// flags: --iters 8
+
 int test(int *x) {
   return x[4096];
 }

--- a/grease-cli/tests/sanity/xfail-panic/empty/test.c
+++ b/grease-cli/tests/sanity/xfail-panic/empty/test.c
@@ -3,4 +3,6 @@
 // This file does *not* have the expected `test` function.
 // See issue gitlab#41.
 
+// flags: --symbol test
+
 // all: check [[Exception: Could not find entrypoint symbol "test"]]

--- a/grease-cli/tests/x86/declare-in-override.x64.cbl
+++ b/grease-cli/tests/x86/declare-in-override.x64.cbl
@@ -3,6 +3,7 @@
 ; A test case that demonstrates that forward declarations can be used in both
 ; Macaw S-expression programs and their overrides (gitlab#159).
 
+; flags: --symbol test
 ; flags: --overrides tests/x86/extra/my-malloc.x64.cbl
 
 ; A forward declaration to a built-in override.

--- a/grease-cli/tests/x86/id.x64.cbl
+++ b/grease-cli/tests/x86/id.x64.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (return regs)))

--- a/grease-cli/tests/x86/null-read.x64.cbl
+++ b/grease-cli/tests/x86/null-read.x64.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (let p (pointer-make-null))

--- a/grease-cli/tests/x86/null-write.x64.cbl
+++ b/grease-cli/tests/x86/null-write.x64.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (let p (pointer-make-null))

--- a/grease-cli/tests/x86/pos-stack-offset-read.x64.cbl
+++ b/grease-cli/tests/x86/pos-stack-offset-read.x64.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (let p (get-field 5 regs))  ;; rsp, stack pointer

--- a/grease-cli/tests/x86/pos-stack-offset-write.x64.cbl
+++ b/grease-cli/tests/x86/pos-stack-offset-write.x64.cbl
@@ -1,5 +1,7 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (let p (get-field 5 regs))  ;; rsp, stack pointer

--- a/grease-cli/tests/x86/user-override.x64.cbl
+++ b/grease-cli/tests/x86/user-override.x64.cbl
@@ -1,5 +1,6 @@
 ; Copyright (c) Galois, Inc. 2024
 
+; flags: --symbol test
 ; flags: --overrides tests/x86/extra/id-ptr.x64.cbl
 
 (declare @id-ptr ((p (Ptr 64))) (Ptr 64))

--- a/grease-cli/tests/x86/write-to-rax-pointer.x64.cbl
+++ b/grease-cli/tests/x86/write-to-rax-pointer.x64.cbl
@@ -2,6 +2,8 @@
 
 ; A test case that writes to a pointer stored in %rax.
 
+; flags: --symbol test
+
 (defun @test ((regs X86Regs)) X86Regs
   (start start:
     (let rax-ptr (get-reg rax regs))


### PR DESCRIPTION
Fixes #117.