### PR TITLE
Write a literate Haskell/Markdown reference for function calls

### DIFF
--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -125,6 +125,9 @@ common shared
 library
   import: shared
   hs-source-dirs: src
+  -- Use Markdown in Literate Haskell (.lhs) files
+  ghc-options: -pgmL markdown-unlit
+  build-tool-depends: markdown-unlit:markdown-unlit
   build-depends:
       aeson >= 2
     , bytestring
@@ -137,6 +140,7 @@ library
     , lens
     , libBF
     , lumberjack >= 1.0 && < 1.1
+    , markdown-unlit ^>= 0.6
     , megaparsec
     , mtl
     , panic >= 0.3

--- a/grease/src/Grease/Macaw/ResolveCall.lhs
+++ b/grease/src/Grease/Macaw/ResolveCall.lhs
@@ -1,0 +1,1 @@
+ResolveCall.md

--- a/grease/src/Grease/Macaw/ResolveCall.md
+++ b/grease/src/Grease/Macaw/ResolveCall.md
@@ -1,3 +1,16 @@
+# Function calls
+
+This document provides a detailed description of how GREASE treats function
+calls in binaries. It is serves as a reference for both users who wish to
+understand and customize GREASE's behavior, and for developers modifying and
+extending the implementation. To that end, it is structured as a literate
+Haskell file, but all the code blocks are hidden by default in collapsable
+sections like the following:
+
+<details>
+<summary>Imports, etc.</summary>
+
+```haskell
 {-|
 Copyright        : (c) Galois, Inc. 2024
 Maintainer       : GREASE Maintainers <grease@galois.com>
@@ -13,79 +26,54 @@ module Grease.Macaw.ResolveCall
   , lookupSyscallHandle
   ) where
 
-import Prelude (Integer, fromIntegral, otherwise, toInteger)
-
-import Control.Applicative (pure)
 import Control.Lens ((^.), (%~), (.~), to)
 import Control.Monad (foldM)
 import Control.Monad.IO.Class (MonadIO(..))
+import Data.BitVector.Sized qualified as BV
 import Data.Foldable (foldl')
-import Data.Function (($), (&), (.))
-import Data.Int (Int)
-import qualified Data.IntMap as IntMap
-import qualified Data.List.NonEmpty as NE
-import qualified Data.Map.Strict as Map
-import Data.Maybe (Maybe(..))
-import Data.Type.Equality (type (~))
-import GHC.Word (Word64)
-import qualified Lumberjack as LJ
-import System.IO (IO)
-
-import qualified Data.BitVector.Sized as BV
-
--- parameterized-utils
-import qualified Data.Parameterized.Context as Ctx
-import qualified Data.Parameterized.Map as MapF
+import Data.Function ((&))
+import Data.IntMap qualified as IntMap
+import Data.List.NonEmpty qualified as NE
+import Data.Macaw.BinaryLoader.ELF qualified as Loader
+import Data.Macaw.CFG qualified as MC
+import Data.Macaw.Discovery qualified as Discovery
+import Data.Macaw.Discovery.Classifier qualified as Discovery
+import Data.Macaw.Memory.ElfLoader qualified as EL
+import Data.Macaw.Symbolic qualified as Symbolic
+import Data.Macaw.Symbolic.Concretize qualified as Symbolic
+import Data.Map.Strict qualified as Map
+import Data.Parameterized.Context qualified as Ctx
+import Data.Parameterized.Map qualified as MapF
 import Data.Parameterized.NatRepr (knownNat)
-
--- what4
-import qualified What4.Expr as W4
-import qualified What4.FunctionName as W4
-import qualified What4.Interface as W4
-import qualified What4.Protocol.Online as W4
-
--- crucible
-import qualified Lang.Crucible.Analysis.Postdom as C
-import qualified Lang.Crucible.Backend as C
-import qualified Lang.Crucible.Backend.Online as C
-import qualified Lang.Crucible.CFG.Core as C
-import qualified Lang.Crucible.CFG.SSAConversion as C
-import qualified Lang.Crucible.CFG.Reg as C.Reg
-import qualified Lang.Crucible.FunctionHandle as C
-import qualified Lang.Crucible.Simulator as C
-
--- crucible-llvm
-import qualified Lang.Crucible.LLVM.MemModel as Mem
-
--- macaw-base
-import qualified Data.Macaw.CFG as MC
-import qualified Data.Macaw.Discovery as Discovery
-import qualified Data.Macaw.Discovery.Classifier as Discovery
-import qualified Data.Macaw.Memory.ElfLoader as EL
-
--- macaw-loader
-import qualified Data.Macaw.BinaryLoader.ELF as Loader
-
--- macaw-symbolic
-import qualified Data.Macaw.Symbolic as Symbolic
-import qualified Data.Macaw.Symbolic.Concretize as Symbolic
-
--- stubs
-import qualified Stubs.FunctionOverride as Stubs
-import qualified Stubs.FunctionOverride.ForwardDeclarations as Stubs
-import qualified Stubs.Memory.Common as Stubs
-import qualified Stubs.Syscall as Stubs
-
+import GHC.Word (Word64)
 import Grease.Diagnostic (Diagnostic(..), GreaseLogAction)
 import Grease.Macaw.Arch
 import Grease.Macaw.Discovery (discoverFunction)
 import Grease.Macaw.FunctionOverride
-import qualified Grease.Macaw.ResolveCall.Diagnostic as Diag
-import Grease.Macaw.SkippedCall (SkippedCall(..))
+import Grease.Macaw.ResolveCall.Diagnostic qualified as Diag
 import Grease.Macaw.SimulatorState
+import Grease.Macaw.SkippedCall (SkippedCall(..))
 import Grease.Macaw.Syscall
 import Grease.Options (ErrorSymbolicFunCalls(..))
 import Grease.Utility (declaredFunNotFound)
+import Lang.Crucible.Analysis.Postdom qualified as C
+import Lang.Crucible.Backend qualified as C
+import Lang.Crucible.Backend.Online qualified as C
+import Lang.Crucible.CFG.Core qualified as C
+import Lang.Crucible.CFG.Reg qualified as C.Reg
+import Lang.Crucible.CFG.SSAConversion qualified as C
+import Lang.Crucible.FunctionHandle qualified as C
+import Lang.Crucible.LLVM.MemModel qualified as Mem
+import Lang.Crucible.Simulator qualified as C
+import Lumberjack qualified as LJ
+import Stubs.FunctionOverride qualified as Stubs
+import Stubs.FunctionOverride.ForwardDeclarations qualified as Stubs
+import Stubs.Memory.Common qualified as Stubs
+import Stubs.Syscall qualified as Stubs
+import What4.Expr qualified as W4
+import What4.FunctionName qualified as W4
+import What4.Interface qualified as W4
+import What4.Protocol.Online qualified as W4
 
 doLog :: MonadIO m => GreaseLogAction -> Diag.Diagnostic -> m ()
 doLog la diag = LJ.writeLog la (ResolveCallDiagnostic diag)
@@ -118,7 +106,16 @@ useComposedOverride halloc arch handle0 override0 st funcName f = do
         regs <- C.callOverride handle0 override0 args
         f (C.regValue regs)
   pure $ useFnHandleAndState handle (C.UseOverride override) st
+```
 
+</details>
+
+## Function calls
+
+<details>
+<summary>Beginning of main logic</summary>
+
+```haskell
 lookupFunctionHandle ::
   forall arch sym bak solver scope st fs p.
   ( C.IsSymBackend sym bak
@@ -145,7 +142,17 @@ lookupFunctionHandle ::
   ErrorSymbolicFunCalls ->
   Symbolic.LookupFunctionHandle p sym arch
 lookupFunctionHandle bak la halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls = Symbolic.LookupFunctionHandle $ \st mem regs -> do
-  -- First, obtain the address contained in the instruction pointer.
+```
+</details>
+
+First, GREASE retrieves the address contained in the instruction pointer
+register. If it is symbolic, an SMT solver is invoked to check if it is
+constrained to a single value.
+
+<details>
+<summary>Obtaining the instruction pointer</summary>
+
+```haskell
   symAddr0 <- (arch ^. archGetIP) regs
   -- Next, attempt to concretize the address. We must do this because it is
   -- possible that the address was obtained from a memory read, and due to the
@@ -162,101 +169,180 @@ lookupFunctionHandle bak la halloc arch memory symMap pltStubs dynFunMap funOvs 
   -- symbolic case cheaper by leveraging the ideas in
   -- https://github.com/GaloisInc/what4/issues/259.
   symAddr1 <- Symbolic.resolveSymBV bak C.knownNat symAddr0
+```
 
-  let -- Treat an external function as a no-op during simulation.
-      skipExternalCall reason = do
-        doLog la $ Diag.SkippedCall reason
-        let funcName = W4.functionNameFromText "_grease_external"
-        handle <- C.mkHandle' halloc funcName (Ctx.Empty Ctx.:> regStructRepr arch) (regStructRepr arch)
-        let override = C.mkOverride' funcName (regStructRepr arch) $ do
-              args <- C.getOverrideArgs
-              let regs' = Ctx.last $ C.regMap args
-              (arch ^. archOffsetStackPointerPostCall) (C.regValue regs')
-        pure $ useFnHandleAndState handle (C.UseOverride override) st
+</details>
 
+If the address cannot be resolved to a concrete value, the function call is
+skipped, i.e., treated as a no-op. If `--error-symbolic-fun-calls` was passed,
+an assertion failure is also generated. Otherwise, the call proceeds.
+  
+<details>
+<summary>Skipping calls to symbolic addresses</summary>
+
+```haskell
+  let skip = skipExternalCall la halloc arch st
   case W4.asBV symAddr1 of
-    -- If asBV returns Nothing here, despite the call to resolveSymBV above,
-    -- then the address is truly symbolic. By default, we skip the call
-    -- entirely, but if the user passes --error-symbolic-fun-calls, then this is
-    -- treated as an error.
     Nothing ->
       if getErrorSymbolicFunCalls errorSymbolicFunCalls
         then C.addFailedAssertion bak $
              C.AssertFailureSimError
                "Failed to call function"
                "Cannot resolve a symbolic function address"
-        else skipExternalCall SymbolicAddress
-    Just bv ->
-      let -- This conversion is safe iff MC.ArchAddrWidth arch <= 64
-          bvWord64 = fromIntegral @Integer @Word64 (BV.asUnsigned bv)
+        else skip SymbolicAddress
+```
+</details>
 
-          -- Call a function handle, unless we have an override in which case call
-          -- the override instead.
-          callHandle hdl st' =
-            case Map.lookup (C.handleName hdl) funOvs of
-              Just macawFnOv ->
-                useMacawFunctionOverride bak la halloc arch funOvs macawFnOv st'
-              Nothing ->
-                pure (hdl, st')
+Next, the absolute address is resolved to an address in the binary. If this
+resolution fails, the call is skipped.
+<!-- TODO: Is that right? -->
 
-          -- Log that we have performed a function call.
-          logFunctionCall fnName = do
-            mbReturnAddr <-
-              (arch ^. archFunctionReturnAddr) bak (arch ^. archVals) regs mem
-            doLog la $ Diag.FunctionCall fnName bvMemWord mbReturnAddr
+<details>
+<summary>Skipping calls to invalid addresses</summary>
 
-          hdls = st ^. stateDiscoveredFnHandles
-          bvMemWord = EL.memWord bvWord64
+```haskell
+    Just bv -> do
+      -- This conversion is safe iff MC.ArchAddrWidth arch <= 64
+      let bvWord64 = fromIntegral @Integer @Word64 (BV.asUnsigned bv)
+      let bvMemWord = EL.memWord bvWord64
+      case Loader.resolveAbsoluteAddress memory bvMemWord of
+        -- TODO: This should probably be a hard error (at least by default)?
+        Nothing -> skip (InvalidAddress (ppMemWord bvMemWord))
+        Just funcAddrOff ->
+          callConcreteAddr bak la halloc arch memory symMap pltStubs dynFunMap funOvs st mem regs bvMemWord funcAddrOff
+  where
+    ppMemWord = BV.ppHex knownNat . BV.word64 . EL.memWordValue
+```
+</details>
+  
+<details>
+<summary>TODO</summary>
 
-          dispatchFuncAddrOff funcAddrOff
-            -- First, check if this is the address of a CFG we have already
-            -- discovered
-            | Just hdl <- Map.lookup funcAddrOff hdls = do
-              logFunctionCall (C.handleName hdl)
-              callHandle hdl st
+```haskell
+callConcreteAddr ::
+  forall arch sym bak solver scope st fs p rtp f a.
+  ( C.IsSymBackend sym bak
+  , Symbolic.SymArchConstraints arch
+  , W4.OnlineSolver solver
+  , sym ~ W4.ExprBuilder scope st fs
+  , bak ~ C.OnlineBackend solver scope st fs
+  , Mem.HasLLVMAnn sym
+  , HasGreaseSimulatorState p sym arch
+  ) =>
+  bak ->
+  GreaseLogAction ->
+  C.HandleAllocator ->
+  ArchContext arch ->
+  EL.Memory (MC.ArchAddrWidth arch) ->
+  -- | Map of entrypoint addresses to their names
+  Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
+  -- | Map of addresses to PLT stub names
+  Map.Map (MC.ArchSegmentOff arch) W4.FunctionName ->
+  -- | Map of dynamic function names to their addresses
+  Map.Map W4.FunctionName (MC.ArchSegmentOff arch) ->
+  -- | Map of names of overridden functions to their implementations
+  Map.Map W4.FunctionName (MacawFunctionOverride p sym arch) ->
+  -- | Current simulator state
+  C.SimState p sym (Symbolic.MacawExt arch) rtp f a ->
+  -- | State of memory
+  Mem.MemImpl sym ->
+  -- | Values of registers
+  Ctx.Assignment (C.RegValue' sym) (Symbolic.MacawCrucibleRegTypes arch) ->
+  -- | Concrete (absolute) address being called
+  EL.MemWord (MC.ArchAddrWidth arch) ->
+  -- | Concrete (resolved) address being called
+  EL.MemSegmentOff (MC.ArchAddrWidth arch) ->
+  IO ( MacawFnHandle arch
+     , C.SimState p sym (Symbolic.MacawExt arch) rtp f a
+     )
+callConcreteAddr bak la halloc arch memory symMap pltStubs dynFunMap funOvs st mem regs bvMemWord funcAddrOff = do
+  -- Call a function handle, unless we have an override in which case call
+  -- the override instead.
+  let callHandle hdl st' =
+        case Map.lookup (C.handleName hdl) funOvs of
+          Just macawFnOv ->
+            useMacawFunctionOverride bak la halloc arch funOvs macawFnOv st'
+          Nothing ->
+            pure (hdl, st')
 
-            -- Next, check if this is a PLT stub.
-            | Just pltStubName <- Map.lookup funcAddrOff pltStubs = do
-              if |  -- If a PLT stub jumps to an address within the same binary
-                    -- or shared library, resolve it...
-                    Just pltCallAddr <- Map.lookup pltStubName dynFunMap
-                 -> do doLog la $ Diag.PltCall pltStubName funcAddrOff pltCallAddr
-                       dispatchFuncAddrOff pltCallAddr
-                 |  otherwise
-                 -> case Map.lookup pltStubName funOvs of
-                      -- ...otherwise, if there is an override for the PLT stub,
-                      -- use it...
-                      Just macawFnOv -> do
-                        logFunctionCall pltStubName
-                        useMacawFunctionOverride bak la halloc arch funOvs macawFnOv st
-                      -- ...otherwise, skip the PLT call entirely.
-                      Nothing -> do
-                        logFunctionCall pltStubName
-                        skipExternalCall (PltNoOverride @arch funcAddrOff pltStubName)
+  let hdls = st ^. stateDiscoveredFnHandles
 
-            -- Finally, check if this is a function that we should explore, and if
-            -- so, use Macaw's code discovery to do so. See Note [Incremental code
-            -- discovery] in Grease.Macaw.SimulatorState.
-            --
-            -- As a simple heuristic for whether a function is worthy of
-            -- exploration, we check if the segment that the address inhabits is
-            -- executable. This check is important to prevent simulating functions
-            -- that, say, inhabit the .data section (which is common for binaries
-            -- that fail the `in-text` requirement), as Macaw will simply crash
-            -- when simulating them.
-            | Discovery.isExecutableSegOff funcAddrOff = do
-              (hdl, st') <-
-                discoverFuncAddr la halloc arch memory symMap pltStubs funcAddrOff st
-              logFunctionCall (C.handleName hdl)
-              callHandle hdl st'
+  if -- First, check if this is the address of a CFG we have already
+     -- discovered
+     | Just hdl <- Map.lookup funcAddrOff hdls -> do
+       logFunctionCall (C.handleName hdl)
+       callHandle hdl st
 
-            | otherwise =
-              skipExternalCall (NotExecutable funcAddrOff)
+     -- Next, check if this is a PLT stub.
+     | Just pltStubName <- Map.lookup funcAddrOff pltStubs -> do
+       if |  -- If a PLT stub jumps to an address within the same binary
+             -- or shared library, resolve it...
+             Just pltCallAddr <- Map.lookup pltStubName dynFunMap
+          -> do doLog la $ Diag.PltCall pltStubName funcAddrOff pltCallAddr
+                callConcreteAddr bak la halloc arch memory symMap pltStubs dynFunMap funOvs st mem regs bvMemWord pltCallAddr
+          |  otherwise
+          -> case Map.lookup pltStubName funOvs of
+               -- ...otherwise, if there is an override for the PLT stub,
+               -- use it...
+               Just macawFnOv -> do
+                 logFunctionCall pltStubName
+                 useMacawFunctionOverride bak la halloc arch funOvs macawFnOv st
+               -- ...otherwise, skip the PLT call entirely.
+               Nothing -> do
+                 logFunctionCall pltStubName
+                 skip (PltNoOverride @arch funcAddrOff pltStubName)
 
-      in case Loader.resolveAbsoluteAddress memory bvMemWord of
-        Nothing -> skipExternalCall (InvalidAddress (BV.ppHex knownNat bv))
-        Just funcAddrOff -> dispatchFuncAddrOff funcAddrOff
+     -- Finally, check if this is a function that we should explore, and if
+     -- so, use Macaw's code discovery to do so. See Note [Incremental code
+     -- discovery] in Grease.Macaw.SimulatorState.
+     --
+     -- As a simple heuristic for whether a function is worthy of
+     -- exploration, we check if the segment that the address inhabits is
+     -- executable. This check is important to prevent simulating functions
+     -- that, say, inhabit the .data section (which is common for binaries
+     -- that fail the `in-text` requirement), as Macaw will simply crash
+     -- when simulating them.
+     | Discovery.isExecutableSegOff funcAddrOff -> do
+       (hdl, st') <-
+         discoverFuncAddr la halloc arch memory symMap pltStubs funcAddrOff st
+       logFunctionCall (C.handleName hdl)
+       callHandle hdl st'
 
+     | otherwise ->
+       skip (NotExecutable funcAddrOff)
+  where
+    skip = skipExternalCall la halloc arch st
+    -- Log that we have performed a function call.
+    logFunctionCall fnName = do
+      mbReturnAddr <-
+        (arch ^. archFunctionReturnAddr) bak (arch ^. archVals) regs mem
+      doLog la $ Diag.FunctionCall fnName bvMemWord mbReturnAddr
+
+-- | Treat an external function as a no-op during simulation.
+skipExternalCall ::
+  C.IsSymInterface sym =>
+  GreaseLogAction ->
+  C.HandleAllocator ->
+  ArchContext arch ->
+  C.SimState p sym (Symbolic.MacawExt arch) rtp f a ->
+  SkippedCall arch ->
+  IO ( MacawFnHandle arch
+     , C.SimState p sym (Symbolic.MacawExt arch) rtp f a
+     )
+skipExternalCall la halloc arch st reason = do
+  doLog la $ Diag.SkippedCall reason
+  let funcName = W4.functionNameFromText "_grease_external"
+  handle <- C.mkHandle' halloc funcName (Ctx.Empty Ctx.:> regStructRepr arch) (regStructRepr arch)
+  let override = C.mkOverride' funcName (regStructRepr arch) $ do
+        args <- C.getOverrideArgs
+        let regs' = Ctx.last $ C.regMap args
+        (arch ^. archOffsetStackPointerPostCall) (C.regValue regs')
+  pure $ useFnHandleAndState handle (C.UseOverride override) st
+```
+
+</details>
+
+```haskell
 -- | An implementation of 'Symbolic.LookupSyscallHandle' that attempts to look
 -- up an override for the syscall, and if one is found, invokes it. If one
 -- cannot be found, the syscall is simulated as a no-op.
@@ -454,3 +540,4 @@ useFnHandleAndState ::
   (C.FnHandle args ret, C.SimState p sym ext r f a)
 useFnHandleAndState fnHdl fnState crucState =
   (fnHdl, Stubs.insertFunctionHandle crucState fnHdl fnState)
+```


### PR DESCRIPTION
This is an unfinished experiment, I'm hoping to gather early feedback to avoid wasted effort if we don't want to move forward with this approach.

This PR enables the creation of hybrid/literate Haskell/Markdown source files, and provides a half-completed demonstration on the `ResolveCall` module.

The motivation is as follows. There are GREASE modules that implement behavior that should probably be (or already is) documented as part of our user-facing reference documentation. Currently, we manage the documentation and the code separately as two files: user-facing docs in `doc/` (e.g., `shape-dsl.md`) and developer-facing implementations in `src/` (e.g., `Shape/Parse.hs`). This system works reasonably well. However, it has a few downsides:

- It is easy to update the code and forget to update the documentation.
- The documentation is often somewhat *duplicated* between the user-facing docs and Haddocks that describe intent (as a small example, consider [this Haddock](https://github.com/GaloisInc/grease/blob/3e85804b12a144aaddadee0981b592f9a272be78/grease/src/Grease/Macaw/FunctionOverride.hs#L173) vs our documentation on overrides)
- If the documentation is not duplicated, then the code is generally missing all description of intent, often with a pointer to the user-facing docs. The reader / developer is then left to (1) context-switch to open another document, and (2) search for the relevant bit of docs for the code they care about. (For an example, see `Parse.hs`).

To address these difficulties, this PR uses `markdown-unlit` together with GHC's native support for literate programming to enable the use of Markdown-formatted `.lhs` source files. The notion is to merge documentation with the code that implements the behaviors being described (for some relatively small number of GREASE modules). Ideally, these documents could be included in our mdBook.

However, this approach would also come with a number of notable downsides:

1. It requires a custom build tool (`markdown-unlit`). This isn't *too* bad, because it can be managed by Cabal.
2. It might degrate editor integrations, see

  - https://github.com/haskell/haskell-language-server/discussions/3949
  - https://github.com/haskell/haskell-language-server/issues/689
  - https://github.com/haskell/hie-bios/issues/187
3. It could degrade other tool support, e.g., `hlint`
3. The code becomes subjectively more "cluttered", albiet with hopefully-helpful explanations of what it does and why
4. The current approach uses symlinks from `.lhs` files to `.md` files so that the latter can be read e.g., on GitHub but GHC still picks them up. I haven't experienced this, but I think there's some folklore that symlinks are not very reliable or uniform cross-platform. I don't necessarily think this is a show-stopper - we can probably avoid symlinks if necessary. We might be able to just include `lhs` files directly into mdBook regardless of their extension, or there might be some hack to get GitHub to render `lhs` files as Markdown.

EDIT: See [here](https://github.com/GaloisInc/grease/blob/7d3db24b5b23908c9f79789297b02e9b224cf34d/grease/src/Grease/Macaw/ResolveCall.md) for what the rendered Markdown looks like. The results from mdBook would likely be quite similar.