### PR TITLE
Respect architecture endianness in Macaw frontend

### DIFF
--- a/grease-aarch32/src/Grease/Macaw/Arch/AArch32.hs
+++ b/grease-aarch32/src/Grease/Macaw/Arch/AArch32.hs
@@ -28,7 +28,6 @@ import qualified Lang.Crucible.Simulator.RegValue as C
 
 -- crucible-llvm
 import qualified Lang.Crucible.LLVM.MemModel as Mem
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 
 -- elf-edit
 import qualified Data.ElfEdit as EE
@@ -83,7 +82,6 @@ armCtx halloc mbReturnAddr stackArgSlots = do
   return
     ArchContext
       { _archInfo = ARM.arm_linux_info
-      , _archEndianness = Mem.LittleEndian
       , _archGetIP = \regs -> do
           let C.RV (Mem.LLVMPointer _base off) = ARM.Symbolic.lookupReg ARM.pc regs
           pure off

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -1314,7 +1314,7 @@ simulateLlvm transOpts simOpts la = do
                 pure (entry, entrypointCfgs)
               Nothing -> throw $ GreaseException $ "Could not find function: " <> nm
 
-    let dl = DataLayout.defaultDataLayout
+    let dl = TCtx.llvmDataLayout (llvmCtxt ^. Trans.llvmTypeCtx)
     let setupHook :: forall sym. LLVM.SetupHook sym
         setupHook = LLVM.SetupHook $ \bak halloc' llvmCtx -> do
           -- Register defined functions...

--- a/grease-cli/tests/Main.hs
+++ b/grease-cli/tests/Main.hs
@@ -251,7 +251,8 @@ main :: IO ()
 main = do
   -- Each entry in this list should be documented in doc/dev.md
   let dirs =
-        [ "llvm"
+        [ "arm"
+        , "llvm"
         , "llvm-bc"
         , "ppc32"
         , "prop"

--- a/grease-cli/tests/arm/htons.armv7l.cbl
+++ b/grease-cli/tests/arm/htons.armv7l.cbl
@@ -1,0 +1,18 @@
+; Copyright (c) Galois, Inc. 2025
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+(declare @htons ((host-short (Bitvector 16))) (Bitvector 16))
+
+(defun @test ((regs AArch32Regs)) AArch32Regs
+  (start start:
+    (let host-short (bv 16 5000))
+    ; AArch32 is little-endian, so `htons` should swap the byte order
+    (let expected-network-short (bv 16 34835))
+    (let actual-network-short (funcall @htons host-short))
+    (assert!
+      (equal? expected-network-short actual-network-short)
+      "htons does not behave as expected")
+    (return regs)))
+;; ok()

--- a/grease-cli/tests/ppc32/htons.ppc32.cbl
+++ b/grease-cli/tests/ppc32/htons.ppc32.cbl
@@ -1,0 +1,18 @@
+; Copyright (c) Galois, Inc. 2025
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+(declare @htons ((host-short (Bitvector 16))) (Bitvector 16))
+
+(defun @test ((regs PPC32Regs)) PPC32Regs
+  (start start:
+    (let host-short (bv 16 5000))
+    ; PowerPC is big-endian, so `htons` should return the input unchanged
+    (let expected-network-short host-short)
+    (let actual-network-short (funcall @htons host-short))
+    (assert!
+      (equal? expected-network-short actual-network-short)
+      "htons does not behave as expected")
+    (return regs)))
+;; ok()

--- a/grease-cli/tests/x86/htons.x64.cbl
+++ b/grease-cli/tests/x86/htons.x64.cbl
@@ -1,0 +1,18 @@
+; Copyright (c) Galois, Inc. 2025
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+(declare @htons ((host-short (Bitvector 16))) (Bitvector 16))
+
+(defun @test ((regs X86Regs)) X86Regs
+  (start start:
+    (let host-short (bv 16 5000))
+    ; x86-64 is little-endian, so `htons` should swap the byte order
+    (let expected-network-short (bv 16 34835))
+    (let actual-network-short (funcall @htons host-short))
+    (assert!
+      (equal? expected-network-short actual-network-short)
+      "htons does not behave as expected")
+    (return regs)))
+;; ok()

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
@@ -27,7 +27,6 @@ import qualified Lang.Crucible.Simulator.RegValue as C
 
 -- crucible-llvm
 import qualified Lang.Crucible.LLVM.MemModel as Mem
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 
 -- elf-edit
 import qualified Data.ElfEdit as EE
@@ -84,7 +83,6 @@ ppc32Ctx mbReturnAddr stackArgSlots = do
   return
     ArchContext
       { _archInfo = PPC.ppc32_linux_info
-      , _archEndianness = Mem.BigEndian
       , _archGetIP = \regs -> do
           C.RV (Mem.LLVMPointer _base off) <- PPC.Symbolic.Regs.lookupReg PPC.PPC_IP regs
           pure off

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
@@ -27,7 +27,6 @@ import qualified Lang.Crucible.Simulator.RegValue as C
 
 -- crucible-llvm
 import qualified Lang.Crucible.LLVM.MemModel as Mem
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 
 -- elf-edit
 import qualified Data.ElfEdit as EE
@@ -93,7 +92,6 @@ ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
   return
     ArchContext
       { _archInfo = PPC.ppc64_linux_info loadedBinary
-      , _archEndianness = Mem.BigEndian
       , _archGetIP = \regs -> do
           C.RV (Mem.LLVMPointer _base off) <- PPC.Symbolic.Regs.lookupReg PPC.PPC_IP regs
           pure off

--- a/grease-x86/src/Grease/Macaw/Arch/X86.hs
+++ b/grease-x86/src/Grease/Macaw/Arch/X86.hs
@@ -27,7 +27,6 @@ import qualified Lang.Crucible.Simulator as C
 
 -- crucible-llvm
 import qualified Lang.Crucible.LLVM.MemModel as Mem
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 
 -- elf-edit
 import qualified Data.ElfEdit as EE
@@ -85,7 +84,6 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
   return
     ArchContext
       { _archInfo = X86.x86_64_linux_info
-      , _archEndianness = Mem.LittleEndian
       , _archVals = avals
       , _archRelocSupported = x64RelocSupported
       , _archGetIP = \regs -> do

--- a/grease/src/Grease/FunctionOverride.hs
+++ b/grease/src/Grease/FunctionOverride.hs
@@ -16,7 +16,7 @@ module Grease.FunctionOverride
   , builtinLLVMOverrides
   ) where
 
-import Control.Lens ((^.))
+import Control.Lens ((^.), to)
 import Data.Bool (Bool(..))
 import Data.Maybe (Maybe(..), mapMaybe)
 import qualified Data.Vector as Vec
@@ -67,18 +67,18 @@ import qualified Lang.Crucible.LLVM.TypeContext as TCtx
 import qualified What4.Interface as W4
 import qualified What4.FunctionName as W4
 
--- macaw
+-- macaw-base
+import qualified Data.Macaw.Architecture.Info as MI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Memory as MM
 
 -- macaw-symbolic
 import qualified Data.Macaw.Symbolic as Symbolic
-import qualified Data.Macaw.Symbolic.Memory.Lazy as Symbolic
 
 -- stubs
 import qualified Stubs.FunctionOverride as Stubs
 
-import Grease.Macaw.Arch (ArchContext, archEndianness)
+import Grease.Macaw.Arch (ArchContext, archInfo)
 import Grease.Macaw.Memory (loadConcreteString)
 import qualified Grease.Panic as Panic
 import Grease.Utility (OnlineSolverAndBackend, llvmOverrideName)
@@ -370,7 +370,7 @@ callAssert ::
 callAssert bak mvar mmConf archCtx _pfn _pfile _pline ptxt = do
   let sym = C.backendGetSym bak
   st0 <- get
-  let endian = Symbolic.fromCrucibleEndian (archCtx ^. archEndianness)
+  let endian = archCtx ^. archInfo . to MI.archEndianness
   let maxSize = Nothing
   (txt, st1) <- liftIO $ loadConcreteString bak mvar mmConf endian ptxt maxSize st0
   put st1
@@ -452,7 +452,7 @@ callPrintf ::
 callPrintf bak mvar mmConf archCtx formatStrPtr gva = do
   let sym = C.backendGetSym bak
   st0 <- get
-  let endian = Symbolic.fromCrucibleEndian (archCtx ^. archEndianness)
+  let endian = archCtx ^. archInfo . to MI.archEndianness
   let maxSize = Nothing
   -- Read format string
   (formatStr, st1) <- liftIO $
@@ -567,7 +567,7 @@ callPuts ::
 callPuts bak mvar mmConf archCtx (C.regValue -> strPtr) = do
   let sym = C.backendGetSym bak
   st0 <- get
-  let endian = Symbolic.fromCrucibleEndian (archCtx ^. archEndianness)
+  let endian = archCtx ^. archInfo . to MI.archEndianness
   let strEntry = C.RegEntry Mem.PtrRepr strPtr
   let maxSize = Nothing
   (str, st1) <- liftIO $ loadConcreteString bak mvar mmConf endian strEntry maxSize st0

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -71,11 +71,11 @@ import qualified Lang.Crucible.Simulator as C
 import qualified Lang.Crucible.Simulator.GlobalState as C
 
 -- crucible-llvm
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 import qualified Lang.Crucible.LLVM.MemModel as Mem
 import qualified Lang.Crucible.LLVM.Intrinsics as Mem
 
 -- macaw-base
+import qualified Data.Macaw.Architecture.Info as MI
 import qualified Data.Macaw.CFG as MC
 import qualified Data.Macaw.Discovery as Discovery
 import qualified Data.Macaw.Memory as MM
@@ -158,7 +158,7 @@ emptyMacawMem bak arch macawMem mutGlobs relocs = do
       (globalMemoryHooks arch relocs)
       (Proxy @arch)
       bak
-      (arch ^. archEndianness)
+      (arch ^. archInfo . to (Symbolic.toCrucibleEndian . MI.archEndianness))
       globs
       macawMem
   pure (InitialMem initMem, ptrTable)
@@ -308,12 +308,12 @@ globalMemoryHooks arch relocs = Symbolic.GlobalMemoryHooks {
           -- appropriate size and endianness.
           relocAbsBaseAddrBs :: BSL.ByteString
           relocAbsBaseAddrBs =
-            case arch ^. archEndianness of
-              Mem.LittleEndian ->
+            case arch ^. archInfo . to MI.archEndianness of
+              MM.LittleEndian ->
                 BSL.take relocSizeInt64 $
                 Builder.toLazyByteString $
                 Builder.word64LE relocAbsBaseAddrWord64
-              Mem.BigEndian ->
+              MM.BigEndian ->
                 BSL.takeEnd relocSizeInt64 $
                 Builder.toLazyByteString $
                 Builder.word64BE relocAbsBaseAddrWord64

--- a/grease/src/Grease/Macaw/Arch.hs
+++ b/grease/src/Grease/Macaw/Arch.hs
@@ -14,7 +14,6 @@ module Grease.Macaw.Arch
   , ArchResult
   , ArchReloc
   , ArchContext(..)
-  , archEndianness
   , archGetIP
   , archInfo
   , archPcReg
@@ -58,7 +57,6 @@ import qualified Lang.Crucible.CFG.Reg as C.Reg
 import qualified Lang.Crucible.Simulator as C
 
 -- crucible-llvm
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 import qualified Lang.Crucible.LLVM.MemModel as Mem
 
 -- macaw-base
@@ -107,7 +105,6 @@ type family ArchReloc arch :: Type
 -- to warrant being a separate data type.
 data ArchContext arch = ArchContext
   { _archInfo :: MI.ArchitectureInfo arch
-  , _archEndianness :: Mem.EndianForm
   , _archGetIP ::
       forall sym.
       C.IsSymInterface sym =>

--- a/grease/src/Grease/Macaw/Load.hs
+++ b/grease/src/Grease/Macaw/Load.hs
@@ -47,9 +47,7 @@ import Text.Read (readMaybe)
 import qualified Lang.Crucible.CFG.Core as C
 
 -- crucible-llvm
-import           Lang.Crucible.LLVM.DataLayout (DataLayout)
 import qualified Lang.Crucible.LLVM.MemModel as Mem
-import qualified Lang.Crucible.LLVM.DataLayout as Mem
 
 -- elf-edit
 import qualified Data.ElfEdit as Elf
@@ -84,8 +82,7 @@ doLog la diag = LJ.writeLog la (LoadDiagnostic diag)
 
 data LoadedProgram arch
   = LoadedProgram
-    { progDataLayout :: DataLayout
-    , progLoadedBinary :: Loader.LoadedBinary arch (Elf.ElfHeaderInfo (MC.ArchAddrWidth arch))
+    { progLoadedBinary :: Loader.LoadedBinary arch (Elf.ElfHeaderInfo (MC.ArchAddrWidth arch))
     , progLoadOptions :: LC.LoadOptions
     , progSymMap :: Map.Map (MC.ArchSegmentOff arch) BS.ByteString
       -- ^ A map of all function addresses to their symbol names. Note that it
@@ -169,7 +166,6 @@ load la userEntrypoints perms elf = do
           (entry,) <$>
           resolveCoreDumpEntrypointAddress la loadOpts mem elf symMap coreDumpPath
   let entryAddrMap = Map.fromList entryAddrs
-  let dl = Mem.defaultDataLayout
 
   let dynFuns = dynamicFunAddrs loadOpts elf
   dynFunSegOffs <-
@@ -196,8 +192,7 @@ load la userEntrypoints perms elf = do
 
   return
     LoadedProgram
-    { progDataLayout = dl
-    , progLoadedBinary = loaded
+    { progLoadedBinary = loaded
     , progLoadOptions = loadOpts
     , progSymMap = symMap
     , progDynFunMap = dynFunMap


### PR DESCRIPTION
We now override the `defaultDataLayout` with a sensible endianness value based on the architecture being used. As a result, functions like `htons` now do different things on different architectures, as expected. This fixes https://github.com/GaloisInc/grease/issues/130.

While I was in the neighborhood, I also cleaned up the handling of endianness in `ArchContext`. `ArchContext` was redundantly storing a separate endianness value that could already be obtained from the `ArchitectureInfo`. As such, I removed the redundant `_archEndianness` field in `ArchContext`, thereby fixing #129.