### PR TITLE
Add bounds to Cabal files

### DIFF
--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.4
+cabal-version: 3.0
 name: grease-cli
 version: 0.1.0.0
 author: Galois, Inc.
@@ -131,33 +131,33 @@ library
     , grease-ppc
     , grease-x86
 
-    , aeson >= 2
-    , async
-    , bytestring
-    , containers
-    , directory
-    , file-embed
-    , filepath
-    , lens
-    , lumberjack >= 1.0 && < 1.1
-    , megaparsec
+    , aeson ^>= 2.2
+    , async ^>= 2.2.5
+    , bytestring ^>= { 0.11.5, 0.12.1 }
+    , containers ^>= 0.6.7
+    , directory ^>= 1.3.7.1
+    , file-embed ^>= 0.0.16
+    , filepath ^>= 1.4.2.2
+    , lens ^>= 5.3
+    , lumberjack ^>= { 1.0, 1.1 }
+    , megaparsec ^>= 9.6
     , optparse-applicative
-    , safe-exceptions
-    , text
-    , vector
+    , safe-exceptions ^>= 0.1.7.4
+    , text ^>= { 2.0, 2.1 }
+    , vector ^>= 0.13.2
 
-    , prettyprinter
-    , parameterized-utils
-    , what4
-    , llvm-pretty
+    , prettyprinter ^>= 1.7.1
+    , parameterized-utils ^>= 2.1.10
+    , what4 ^>= 1.6
+    , llvm-pretty ^>= 0.12
     , llvm-pretty-bc-parser
-    , crucible
-    , crucible-debug
+    , crucible ^>= 0.7.1
+    , crucible-debug ^>= 0.1
     , crucible-llvm-debug
-    , crucible-llvm
+    , crucible-llvm ^>= 0.7
     , crucible-llvm-syntax
     , crucible-macaw-debug
-    , crucible-syntax
+    , crucible-syntax ^>= 0.4
     , elf-edit
     , macaw-loader
     , macaw-loader-aarch32
@@ -201,21 +201,21 @@ test-suite grease-tests
   build-depends:
       grease-cli
     , grease
-    , bv-sized
-    , bytestring
-    , containers
-    , crucible-llvm
-    , directory
-    , file-embed
-    , filepath
-    , hedgehog
-    , hslua
-    , lumberjack
+    , bv-sized ^>= 1.0.6
+    , bytestring ^>= { 0.11.5, 0.12.1 }
+    , containers ^>= 0.6.7
+    , directory ^>= 1.3.7.1
+    , crucible-llvm ^>= 0.7
+    , file-embed ^>= 0.0.16
+    , filepath ^>= 1.4.2.2
+    , hedgehog ^>= 1.5
+    , hslua ^>= 2.3.1
+    , lumberjack ^>= { 1.0, 1.1 }
     , macaw-base
     , oughta ^>= 0.2
-    , parameterized-utils
-    , prettyprinter
-    , tasty
-    , tasty-hedgehog
-    , tasty-hunit
-    , text
+    , parameterized-utils ^>= 2.1.10
+    , prettyprinter ^>= 1.7.1
+    , tasty ^>= 1.5.3
+    , tasty-hedgehog ^>= 1.4.0.2
+    , tasty-hunit ^>= 0.10.2
+    , text ^>= { 2.0, 2.1 }

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -131,6 +131,7 @@ library
     , grease-ppc
     , grease-x86
 
+    -- Hackage dependencies
     , aeson ^>= 2.2
     , async ^>= 2.2.5
     , bytestring ^>= { 0.11.5, 0.12.1 }
@@ -145,36 +146,40 @@ library
     , safe-exceptions ^>= 0.1.7.4
     , text ^>= { 2.0, 2.1 }
     , vector ^>= 0.13.2
-
     , prettyprinter ^>= 1.7.1
     , parameterized-utils ^>= 2.1.10
-    , what4 ^>= 1.6
-    , llvm-pretty ^>= 0.12
-    , llvm-pretty-bc-parser
-    , crucible ^>= 0.7.1
-    , crucible-debug ^>= 0.1
+
+    -- Submodules
+    --
+    -- No version bounds are needed, as Cabal will always choose the versions
+    -- specified in `cabal.project`, namely, the version in the submodule.
+    , crucible
+    , crucible-debug
+    , crucible-llvm
     , crucible-llvm-debug
-    , crucible-llvm ^>= 0.7
     , crucible-llvm-syntax
     , crucible-macaw-debug
-    , crucible-syntax ^>= 0.4
+    , crucible-syntax
     , elf-edit
-    , macaw-loader
-    , macaw-loader-aarch32
-    , macaw-loader-x86
-    , macaw-base
-    , macaw-symbolic
-    , macaw-symbolic-syntax
+    , llvm-pretty
+    , llvm-pretty-bc-parser
     , macaw-aarch32
     , macaw-aarch32-symbolic
     , macaw-aarch32-syntax
+    , macaw-base
+    , macaw-loader
+    , macaw-loader-aarch32
+    , macaw-loader-x86
     , macaw-ppc
     , macaw-ppc-symbolic
     , macaw-ppc-syntax
+    , macaw-symbolic
+    , macaw-symbolic-syntax
     , macaw-x86
     , macaw-x86-symbolic
     , macaw-x86-syntax
     , stubs-common
+    , what4
 
   exposed-modules:
     Grease.Cli
@@ -201,17 +206,17 @@ test-suite grease-tests
   build-depends:
       grease-cli
     , grease
+
+    -- Hackage dependencies
     , bv-sized ^>= 1.0.6
     , bytestring ^>= { 0.11.5, 0.12.1 }
     , containers ^>= 0.6.7
     , directory ^>= 1.3.7.1
-    , crucible-llvm ^>= 0.7
     , file-embed ^>= 0.0.16
     , filepath ^>= 1.4.2.2
     , hedgehog ^>= 1.5
     , hslua ^>= 2.3.1
     , lumberjack ^>= { 1.0, 1.1 }
-    , macaw-base
     , oughta ^>= 0.2
     , parameterized-utils ^>= 2.1.10
     , prettyprinter ^>= 1.7.1
@@ -219,3 +224,7 @@ test-suite grease-tests
     , tasty-hedgehog ^>= 1.4.0.2
     , tasty-hunit ^>= 0.10.2
     , text ^>= { 2.0, 2.1 }
+
+    -- Submodules
+    , crucible-llvm
+    , macaw-base

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -126,7 +126,9 @@ library
   import: shared
   hs-source-dirs: src
   build-depends:
+    -- Hackage dependencies
       aeson ^>= 2.2
+    , bv-sized ^>= 1.0.6
     , bytestring ^>= { 0.11.5, 0.12.1 }
     , containers ^>= 0.6.7
     , directory ^>= 1.3.7.1
@@ -140,30 +142,33 @@ library
     , megaparsec ^>= 9.6
     , mtl ^>= { 2.3.1, 2.2.2 }
     , panic ^>= 0.4
+    , parameterized-utils ^>= 2.1.10
+    , prettyprinter ^>= 1.7.1
     , safe-exceptions ^>= 0.1.7.4
     , text ^>= { 2.0, 2.1 }
     , time ^>= 1.12.2
     , transformers ^>= { 0.5.6.2, 0.6.1 }
     , vector ^>= 0.13.2
 
-    , prettyprinter ^>= 1.7.1
-    , parameterized-utils ^>= 2.1.10
-    , bv-sized ^>= 1.0.6
-    , what4 ^>= 1.6
-    , llvm-pretty ^>= 0.12
-    , crucible ^>= 0.7.1
-    , crucible-debug ^>= 0.1
-    , crucible-llvm ^>= 0.7
+    -- Submodules
+    --
+    -- No version bounds are needed, as Cabal will always choose the versions
+    -- specified in `cabal.project`, namely, the version in the submodule.
+    , crucible
+    , crucible-debug
+    , crucible-llvm
     , crucible-llvm-syntax
-    , crucible-syntax ^>= 0.4
+    , crucible-syntax
     , elf-edit
     , elf-edit-core-dump
-    , macaw-loader
+    , llvm-pretty
     , macaw-base
+    , macaw-loader
     , macaw-symbolic
     , macaw-symbolic-syntax
     , stubs-common
     , stubs-wrapper
+    , what4
 
   exposed-modules:
     Grease.Main.Diagnostic

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -1,4 +1,4 @@
-cabal-version: 2.4
+cabal-version: 3.0
 name: grease
 version: 0.1.0.0
 author: Galois, Inc.
@@ -126,36 +126,36 @@ library
   import: shared
   hs-source-dirs: src
   build-depends:
-      aeson >= 2
-    , bytestring
-    , containers
-    , directory
-    , exceptions
-    , file-embed >= 0.0.16
-    , filepath
-    , gitrev
-    , lens
-    , libBF
-    , lumberjack >= 1.0 && < 1.1
-    , megaparsec
-    , mtl
-    , panic >= 0.3
-    , safe-exceptions
-    , text
-    , time
-    , transformers
-    , vector
+      aeson ^>= 2.2
+    , bytestring ^>= { 0.11.5, 0.12.1 }
+    , containers ^>= 0.6.7
+    , directory ^>= 1.3.7.1
+    , exceptions ^>= 0.10.5
+    , file-embed ^>= 0.0.16
+    , filepath ^>= 1.4.2.2
+    , gitrev ^>= 1.3
+    , lens ^>= 5.3
+    , libBF ^>= 0.6.8
+    , lumberjack ^>= { 1.0, 1.1 }
+    , megaparsec ^>= 9.6
+    , mtl ^>= { 2.3.1, 2.2.2 }
+    , panic ^>= 0.4
+    , safe-exceptions ^>= 0.1.7.4
+    , text ^>= { 2.0, 2.1 }
+    , time ^>= 1.12.2
+    , transformers ^>= { 0.5.6.2, 0.6.1 }
+    , vector ^>= 0.13.2
 
-    , prettyprinter
-    , parameterized-utils
-    , bv-sized
-    , what4
-    , llvm-pretty
-    , crucible
-    , crucible-debug
-    , crucible-llvm
+    , prettyprinter ^>= 1.7.1
+    , parameterized-utils ^>= 2.1.10
+    , bv-sized ^>= 1.0.6
+    , what4 ^>= 1.6
+    , llvm-pretty ^>= 0.12
+    , crucible ^>= 0.7.1
+    , crucible-debug ^>= 0.1
+    , crucible-llvm ^>= 0.7
     , crucible-llvm-syntax
-    , crucible-syntax
+    , crucible-syntax ^>= 0.4
     , elf-edit
     , elf-edit-core-dump
     , macaw-loader


### PR DESCRIPTION
Fixes #136. Skips the architecture-specific ones, as the dependencies of these are either (1) covered by `grease{,-cli}` or (2) unversioned Macaw architecture-specific packages.