### PR TITLE
ci: Build against additional dependency versions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,25 +28,6 @@ jobs:
         haddock: [true]  # see `include` below
         os: [ubuntu-22.04]
         pre-hook: [""]  # see `include` below
-        include:
-        # Include a build (with latest Linux OS) against Stackage LTS package
-        # sets for each supported version of GHC that has one to verify that we
-        # support building against these widely-used package sets.
-        - cabal: "3.14.1.1"
-          cache-key-prefix: stackage
-          ghc: 9.8.4
-          haddock: false
-          os: ubuntu-22.04
-          pre-hook: |
-            echo 'import: https://www.stackage.org/lts-23.19/cabal.config' >> cabal.project
-        - cabal: "3.14.1.1"
-          cache-key-prefix: stackage
-          ghc: 9.4.8
-          haddock: false
-          os: ubuntu-22.04
-          pre-hook: |
-            echo 'import: https://www.stackage.org/lts-21.25/cabal.config' >> cabal.project
-    name: GREASE - GHC v${{ matrix.ghc }} - ${{ cache-key-prefix }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,22 +14,48 @@ env:
   # a valid version of the "happy" tool).
   CACHE_VERSION: 1
 
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
-      matrix:
-        ghc: ["9.4.8", "9.6.6", "9.8.4"]
-        cabal: ["3.14.1.1"]
-        os: [ubuntu-22.04]
       # complete all jobs
       fail-fast: false
-    name: GREASE - GHC v${{ matrix.ghc }}
+      matrix:
+        cabal: ["3.14.1.1"]
+        cache-key-prefix: [""]  # see `include` below
+        ghc: ["9.4.8", "9.6.6", "9.8.4"]
+        haddock: [true]  # see `include` below
+        os: [ubuntu-22.04]
+        pre-hook: [""]  # see `include` below
+        include:
+        # Include a build (with latest Linux OS) against Stackage LTS package
+        # sets for each supported version of GHC that has one to verify that we
+        # support building against these widely-used package sets.
+        - cabal: "3.14.1.1"
+          cache-key-prefix: stackage
+          ghc: 9.8.4
+          haddock: false
+          os: ubuntu-22.04
+          pre-hook: |
+            echo 'import: https://www.stackage.org/lts-23.19/cabal.config' >> cabal.project
+        - cabal: "3.14.1.1"
+          cache-key-prefix: stackage
+          ghc: 9.4.8
+          haddock: false
+          os: ubuntu-22.04
+          pre-hook: |
+            echo 'import: https://www.stackage.org/lts-21.25/cabal.config' >> cabal.project
+    name: GREASE - GHC v${{ matrix.ghc }} - ${{ cache-key-prefix }}
     steps:
     - name: Checkout
       uses: actions/checkout@v4
       with:
         submodules: true
+
+    - name: Run pre-hook
+      shell: bash
+      run: ${{ matrix.pre-hook }}
 
     - name: Setup Haskell
       uses: haskell-actions/setup@v2
@@ -40,13 +66,14 @@ jobs:
 
     - name: Restore cabal store cache
       uses: actions/cache/restore@v4
+      id: cache
       with:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ github.sha }}
+        key: ${{ matrix.cache-key-prefix }}-${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ github.sha }}
         restore-keys: |
-          ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-
+          ${{ matrix.cache-key-prefix }}-${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-
 
     - name: Install solvers
       shell: bash
@@ -86,6 +113,7 @@ jobs:
       run: cabal run exe:grease-diagrams -- --output doc/mem.svg --width 400 --height 400
 
     - name: Haddock
+      if: ${{ matrix.haddock }}
       shell: bash
       # Build the Haddocks to ensure that they are well formed. Somewhat
       # counterintuitively, we run this with the --disable-documentation flag.
@@ -106,5 +134,4 @@ jobs:
         path: |
           ${{ steps.setup-haskell.outputs.cabal-store }}
           dist-newstyle
-        key: ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-${{ github.sha }}
-          ${{ env.CACHE_VERSION }}-cabal-${{ matrix.os }}-${{ matrix.ghc }}-
+        key: ${{ steps.cache.outputs.cache-primary-key }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,7 +50,10 @@ jobs:
               gunzip > \
               /usr/local/bin/cabal-force-upper-bound
             chmod +x /usr/local/bin/cabal-force-upper-bound
-            for f in ./grease*/grease*.cabal; do
+            for f in \
+                ./doc/diagrams/grease-diagrams.cabal \
+                ./elf-edit-core-dump/elf-edit-core-dump.cabal \
+                ./grease*/grease*.cabal; do
               cabal-force-upper-bound --cabal-project "${f}" >> cabal.project
             done
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   build:
+    name: GREASE - GHC v${{ matrix.ghc }} - ${{ matrix.cache-key-prefix }}
     runs-on: ${{ matrix.os }}
     strategy:
       # complete all jobs
@@ -28,6 +29,30 @@ jobs:
         haddock: [true]  # see `include` below
         os: [ubuntu-22.04]
         pre-hook: [""]  # see `include` below
+        include:
+        # Include a single build (with latest Linux OS and latest GHC version)
+        # using `cabal-force-upper-bounds` to verify that we actually build
+        # against the upper bounds in the Cabal `build-depends`.
+        - cabal: "3.14.1.1"
+          cache-key-prefix: upper-bounds
+          ghc: 9.8.4
+          haddock: false
+          os: ubuntu-22.04
+          pre-hook: |
+            curl \
+              --fail \
+              --location \
+              --proto '=https' \
+              --show-error \
+              --silent \
+              --tlsv1.2 \
+              https://github.com/nomeata/cabal-force-upper-bound/releases/download/0.1/cabal-force-upper-bound.linux.gz | \
+              gunzip > \
+              /usr/local/bin/cabal-force-upper-bound
+            chmod +x /usr/local/bin/cabal-force-upper-bound
+            for f in ./grease*/grease*.cabal; do
+              cabal-force-upper-bound --cabal-project "${f}" >> cabal.project
+            done
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,6 +30,16 @@ jobs:
         os: [ubuntu-22.04]
         pre-hook: [""]  # see `include` below
         include:
+        # Include a single build (with latest Linux OS and oldest GHC version)
+        # using `--prefer-oldest` to verify that we still build against the
+        # lower bounds in the Cabal `build-depends`.
+        - cabal: "3.14.1.1"
+          cache-key-prefix: prefer-oldest
+          ghc: 9.4.8
+          haddock: false
+          os: ubuntu-22.04
+          pre-hook: |
+            echo 'prefer-oldest: True' >> cabal.project
         # Include a single build (with latest Linux OS and latest GHC version)
         # using `cabal-force-upper-bounds` to verify that we actually build
         # against the upper bounds in the Cabal `build-depends`.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,16 +30,6 @@ jobs:
         os: [ubuntu-22.04]
         pre-hook: [""]  # see `include` below
         include:
-        # Include a single build (with latest Linux OS and oldest GHC version)
-        # using `--prefer-oldest` to verify that we still build against the
-        # lower bounds in the Cabal `build-depends`.
-        - cabal: "3.14.1.1"
-          cache-key-prefix: prefer-oldest
-          ghc: 9.4.8
-          haddock: false
-          os: ubuntu-22.04
-          pre-hook: |
-            echo 'prefer-oldest: True' >> cabal.project
         # Include a single build (with latest Linux OS and latest GHC version)
         # using `cabal-force-upper-bounds` to verify that we actually build
         # against the upper bounds in the Cabal `build-depends`.

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -140,7 +140,7 @@ library
     , file-embed ^>= 0.0.16
     , filepath ^>= 1.4.2.2
     , lens ^>= 5.3
-    , lumberjack ^>= { 1.0, 1.1 }
+    , lumberjack ^>= 1.0
     , megaparsec ^>= 9.6
     , optparse-applicative
     , safe-exceptions ^>= 0.1.7.4
@@ -217,7 +217,7 @@ test-suite grease-tests
     , filepath ^>= 1.4.2.2
     , hedgehog ^>= 1.5
     , hslua ^>= 2.3.1
-    , lumberjack ^>= { 1.0, 1.1 }
+    , lumberjack ^>= 1.0
     , oughta ^>= 0.2
     , parameterized-utils ^>= 2.1.10
     , prettyprinter ^>= 1.7.1

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -138,7 +138,7 @@ library
     , githash ^>=0.1.7.0
     , lens ^>= 5.3
     , libBF ^>= 0.6.8
-    , lumberjack ^>= { 1.0, 1.1 }
+    , lumberjack ^>= 1.0
     , megaparsec ^>= 9.6
     , mtl ^>= { 2.3.1, 2.2.2 }
     , panic ^>= 0.4


### PR DESCRIPTION
Currently based on #140. Meant to ensure that we (1) maintain compatibility with a sufficiently-wide range of versions of our dependencies (by building against Stackage LTS) and (2) that our version bounds are accurate (by building with `--prefer-oldest`).