### PR TITLE
ci: Run `typos` tool on docs to catch typos

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,6 +24,13 @@ jobs:
 
           ./hlint-3.8/hlint grease{,-aarch32,-ppc,-x86}/src grease-cli/{main,src,tests}
 
+      - name: Spell check docs
+        # We pin a specific version because updates can come with additional
+        # typo fixes. These could break CI unexpectedly if we just pinned @v1.
+        uses: crate-ci/typos@v1.32.0
+        with:
+          files: doc/
+
       - name: Find stale TODOs
         shell: bash
         env:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,10 +18,15 @@ jobs:
 
       - shell: bash
         run: |
-          curl -fsS --location -o hlint.tar.gz \
-            https://github.com/ndmitchell/hlint/releases/download/v3.8/hlint-3.8-x86_64-linux.tar.gz
-          tar xvf hlint.tar.gz
-
+          curl \
+            --fail \
+            --location \
+            --proto '=https' \
+            --show-error \
+            --silent \
+            --tlsv1.2 \
+            https://github.com/ndmitchell/hlint/releases/download/v3.8/hlint-3.8-x86_64-linux.tar.gz | \
+            tar xzf - hlint-3.8/hlint
           ./hlint-3.8/hlint grease{,-aarch32,-ppc,-x86}/src grease-cli/{main,src,tests}
 
       - name: Spell check docs

--- a/doc/dev.md
+++ b/doc/dev.md
@@ -158,13 +158,13 @@ organized into different subdirectories:
    test cases has the file extension `*.bc`.
 
 3. `arm`: AArch32 machine-code CFGs (via `macaw-aarch32-syntax`). Each of these
-   test cases has the file exension `*.armv7l.cbl`.
+   test cases has the file extension `*.armv7l.cbl`.
 
 4. `ppc32`: PPC32 machine-code CFGs (via `macaw-ppc-syntax`). Each of these test
-   cases has the file exension `*.ppc32.cbl`.
+   cases has the file extension `*.ppc32.cbl`.
 
 5. `x86`: x86-64 machine-code CFGs (via `macaw-x86-syntax`). Each of these test
-   cases has the file exension `*.x64.cbl`.
+   cases has the file extension `*.x64.cbl`.
 
 ### Lua API
 

--- a/doc/memory-model.md
+++ b/doc/memory-model.md
@@ -50,7 +50,7 @@ Mutable global variables are tricky:
   trigger the bug isn't actually feasible at any of the callsites to the
   function under analysis.
 - On the other hand, if GREASE doesn't initialize global variables at all, any
-  loads from them (that aren't preceeded by writes made by the function under
+  loads from them (that aren't preceded by writes made by the function under
   analysis or its callees) will fail. As mutable global variables are pervasive,
   this would lead to a significant lack of coverage.
 

--- a/doc/shape-dsl.md
+++ b/doc/shape-dsl.md
@@ -32,7 +32,7 @@ Where:
 - `uninit N` represents `N` uninitialized bytes of memory
 - `init N` represents `N` bytes of memory initialized to symbolic bytes
 - `exactly byte+` represents a concrete sequence of bytes
-- `memptr` represents a pointer to a futher allocation
+- `memptr` represents a pointer to a further allocation
 
 At certain verbosity levels, GREASE may output these preconditions in its logs.
 It does so using a concrete syntax described below.

--- a/doc/shared-libraries.md
+++ b/doc/shared-libraries.md
@@ -37,7 +37,7 @@ relocation type associated with the PLT stub, e.g.,
 grease: Attempted to read from an unsupported relocation type (R_X86_64_GLOB_DAT) at address 0x3ff0.
 This may be due to a PLT stub that grease did not detect.
 If so, try passing --plt-stub <ADDR>:<NAME>, where
-<ADDR> and <NAME> can be obtained by diassembling the
+<ADDR> and <NAME> can be obtained by disassembling the
 relevant PLT section of the binary
 (.plt, .plt.got, .plt.sec, etc.).
 ```

--- a/doc/undefined-behavior.md
+++ b/doc/undefined-behavior.md
@@ -14,7 +14,7 @@ In the C abstract machine, such behavior is clearly undefined.
 However, if the program is compiled in a straightforward way into machine code, the distinction between different stack variables is lost.
 The resulting code simply performs several innocuous-looking writes to the stack.
 Similarly, adding two signed integers in C might result in an undefined signed overflow.
-At the machine code level, there is no distinction betwen signed and unsigned integers, and arithmetic operations generally have a well-defined semantics for all inputs (e.g., based on a two's complement representation).
+At the machine code level, there is no distinction between signed and unsigned integers, and arithmetic operations generally have a well-defined semantics for all inputs (e.g., based on a two's complement representation).
 
 GREASE aims to be pragmatic in what it calls a bug.
 It uses a C-like memory model, and reports behaviors of binaries that would likely constitute undefined behavior in C.

--- a/grease-cli/tests/Makefile
+++ b/grease-cli/tests/Makefile
@@ -58,7 +58,7 @@ STRIPPED_STATIC_ARM_EXES   = $(addsuffix /test.armv7l.elf,$(STRIPPED_STATIC_DIRS
 STRIPPED_STATIC_X64_EXES   = $(addsuffix /test.x64.elf,$(STRIPPED_STATIC_DIRS))
 STRIPPED_STATIC_PPC32_EXES = $(addsuffix /test.ppc32.elf,$(STRIPPED_STATIC_DIRS))
 
-# Thest test cases depend on libc, but rely on static linking to ensure that
+# These test cases depend on libc, but rely on static linking to ensure that
 # all of the relevant code from libc is inlined into the binary.
 #
 # For instance, the sanity/pass/syscall test case crucially relies

--- a/grease-cli/tests/llvm/double-free.llvm.cbl
+++ b/grease-cli/tests/llvm/double-free.llvm.cbl
@@ -11,5 +11,5 @@
 ;; next_line_must_fail()
     (funcall h p)
     (return ())))
-; TODO: This error mesage is not great... it doesn't mention double-frees
+; TODO: This error message is not great... it doesn't mention double-frees
 ;; check "The free function"

--- a/grease/src/Grease/LLVM/Overrides.hs
+++ b/grease/src/Grease/LLVM/Overrides.hs
@@ -347,7 +347,7 @@ registerLLVMOverrides la builtinOvs paths bak halloc llvmCtx decls = do
       Just ov -> registerOv ov
 
   -- Note the order again: user overrides (registered later) will take
-  -- precendence over built-in overrides (registered here).
+  -- precedence over built-in overrides (registered here).
   let ovs = Foldable.toList builtinOvs
   builtinOvs' <- CLLVM.register_llvm_overrides_ llvmCtx ovs allDecls
   builtinOvs'' <-

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -505,7 +505,7 @@ assertRelocSupported arch (Mem.LLVMPointer _base offset) relocs =
                  ") at address " <> tshow addr <> "."
                , "This may be due to a PLT stub that grease did not detect."
                , "If so, try passing --plt-stub <ADDR>:<NAME>, where"
-               , "<ADDR> and <NAME> can be obtained by diassembling the"
+               , "<ADDR> and <NAME> can be obtained by disassembling the"
                , "relevant PLT section of the binary"
                , "(.plt, .plt.got, .plt.sec, etc.)."
                ]

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -93,7 +93,7 @@ doLog la diag = LJ.writeLog la (ResolveCallDiagnostic diag)
 regStructRepr :: ArchContext arch -> C.TypeRepr (Symbolic.ArchRegStruct arch)
 regStructRepr arch = C.StructRepr . Symbolic.crucArchRegTypes $ arch ^. archVals . to Symbolic.archFunctions
 
--- | Create a new override that post-composes an 'OverrideSim' action wtih an existing one.
+-- | Create a new override that post-composes an 'OverrideSim' action with an existing one.
 useComposedOverride ::
   C.HandleAllocator ->
   ArchContext arch ->

--- a/grease/src/Grease/Macaw/SimulatorHooks.hs
+++ b/grease/src/Grease/Macaw/SimulatorHooks.hs
@@ -49,7 +49,7 @@ doLog la diag = LJ.writeLog la (SimulatorHooksDiagnostic diag)
 -- operations.
 --
 -- Wraps around a base ExtensionImpl that is invoked in cases where
--- greaseMacawExtImpl does not override the default beahvior.
+-- greaseMacawExtImpl does not override the default behavior.
 --
 -- We override several pointer operations because their implementations
 -- in "Data.Macaw.Symbolic.MemOps" invent fresh symbolic constants via

--- a/grease/src/Grease/Options.hs
+++ b/grease/src/Grease/Options.hs
@@ -78,7 +78,7 @@ data SimOpts
   = SimOpts
     { -- | Run the debugger execution feature
       simDebug :: Bool
-      -- | Names or addresss of function to simulate
+      -- | Names or address of function to simulate
     , simEntryPoints :: [Entrypoint]
       -- | Default: 'False'.
     , simErrorSymbolicFunCalls :: ErrorSymbolicFunCalls
@@ -87,7 +87,7 @@ data SimOpts
       -- | Maximum number of iterations of each program loop/maximum number of
       -- recursive calls to the same function
     , simLoopBound :: LoopBound
-      -- | Maxmimum number of iterations of the refinement loop
+      -- | Maximum number of iterations of the refinement loop
     , simMaxIters :: Maybe Int
       -- | How to initialize mutable globals
     , simMutGlobs :: MutableGlobalState

--- a/grease/src/Grease/Panic.hs
+++ b/grease/src/Grease/Panic.hs
@@ -15,7 +15,7 @@ data Grease = Grease
 --   arise due to a programming error. It will exit the program
 --   and print a message asking users to open a ticket.
 panic :: HasCallStack =>
-  String {- ^ Short name of where the error occured -} ->
+  String {- ^ Short name of where the error occurred -} ->
   [String] {- ^ More detailed description of the error  -} ->
   a
 panic = Panic.panic Grease

--- a/grease/src/Grease/Shape/Pointer.hs
+++ b/grease/src/Grease/Shape/Pointer.hs
@@ -335,7 +335,7 @@ growPtrTarget ::
   PtrTarget wptr tag
 growPtrTarget = growPtrTargetBy (Bytes.toBytes (1 :: Integer))
 
--- | Inintialize all uninitialized parts of an allocation
+-- | Initialize all uninitialized parts of an allocation
 initializePtrTarget ::
   Semigroup (tag (C.VectorType (Mem.LLVMPointerType 8))) =>
   -- | Tag for newly-initialized bytes
@@ -345,7 +345,7 @@ initializePtrTarget ::
 initializePtrTarget tag (PtrTarget ms) =
   ptrTarget (fmap (initializeMemShape tag) ms)
 
--- | Inintialize all uninitialized parts of an allocation, or if it is already
+-- | Initialize all uninitialized parts of an allocation, or if it is already
 -- fully initialized, grow it by one uninitialized byte.
 initializeOrGrowPtrTarget ::
   Semigroup (tag (C.VectorType (Mem.LLVMPointerType 8))) =>

--- a/grease/src/Grease/Shape/Print.hs
+++ b/grease/src/Grease/Shape/Print.hs
@@ -108,7 +108,7 @@ evalPrinter cfg p =
 
 printerAlloc :: Printer w (PP.Doc Void) -> Printer w BlockId
 printerAlloc computeDoc = do
-  -- The seqencing of block number allocations is important for legibility: It's
+  -- The sequencing of block number allocations is important for legibility: It's
   -- nicer when pointers have lower block numbers than the pointers inside the
   -- allocation that they point to, because then allocation numbers increase
   -- while reading right-to-left, top-to-bottom.


### PR DESCRIPTION
Seems to have no false positives on the documentation, so seems nice to have in CI. It does have some false positives on `grease*/`, so we can't check that in CI. I ran it manually and fixed some typos.

https://github.com/crate-ci/typos