### PR TITLE
Use project-relative file embeddings

### DIFF
--- a/grease-cli/src/Grease/Profiler/EmbeddedData.hs
+++ b/grease-cli/src/Grease/Profiler/EmbeddedData.hs
@@ -11,7 +11,7 @@ module Grease.Profiler.EmbeddedData
 
 import Data.Bifunctor (Bifunctor(..))
 import Data.ByteString (ByteString)
-import Data.FileEmbed (embedDir, embedFile)
+import Data.FileEmbed (embedDir, embedFileRelative, makeRelativeToProject)
 import System.FilePath ((</>))
 
 import Grease.Profiler.Paths (profilerDir, profileHtmlPath)
@@ -21,9 +21,9 @@ import Grease.Profiler.Paths (profilerDir, profileHtmlPath)
 -- Template Haskell file dependency tracking.
 profilerDataFiles :: [(FilePath, ByteString)]
 profilerDataFiles =
-  let cssFiles = map (first ("css" </>)) ($(embedDir $ profilerDir </> "css"))
-      jsFiles  = map (first ("js"  </>)) ($(embedDir $ profilerDir </> "js"))
-      tsFiles  = map (first ("ts"  </>)) ($(embedDir $ profilerDir </> "ts"))
-      profileHtmlContents = $(embedFile $ profilerDir </> profileHtmlPath)
+  let cssFiles = map (first ("css" </>)) ($(makeRelativeToProject (profilerDir </> "css") >>= embedDir))
+      jsFiles  = map (first ("js"  </>)) ($(makeRelativeToProject (profilerDir </> "js") >>= embedDir))
+      tsFiles  = map (first ("ts"  </>)) ($(makeRelativeToProject (profilerDir </> "ts") >>= embedDir))
+      profileHtmlContents = $(embedFileRelative (profilerDir </> profileHtmlPath))
   in (profileHtmlPath, profileHtmlContents)
    : concat @[] [cssFiles, jsFiles, tsFiles]

--- a/grease-cli/tests/Main.hs
+++ b/grease-cli/tests/Main.hs
@@ -14,7 +14,7 @@ module Main (main) where
 import Control.Exception qualified as X
 import Control.Monad (forM, forM_)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.FileEmbed (embedFile)
+import Data.FileEmbed (embedFileRelative)
 import Data.Functor ((<&>))
 import Data.IORef qualified as IORef
 import Data.List qualified as List
@@ -42,7 +42,7 @@ import Test.Tasty qualified as T
 import Test.Tasty.HUnit qualified as T.U
 
 prelude :: Text.Text
-prelude = Text.decodeUtf8 $(embedFile "tests/test.lua")
+prelude = Text.decodeUtf8 $(embedFileRelative "tests/test.lua")
 
 data Arch = Armv7 | PPC32 | X64
   deriving Eq


### PR DESCRIPTION
Avoids issues related to assumptions about current working directories at the command line vs. within HLS.

Context: before these changes, `cabal build all` at the command line would succeed, but if you instead opened a fresh checkout of the grease repo in VSCode with the Haskell (HLS) extension you would get a compilation failure:

```
• Exception when trying to run compile-time code:
    ../deps/sympro-ui/css: getDirectoryContents:openDirStream: does not exist (No such file or directory)
  Code: (embedDir $ profilerDir </> "css")
• In the untyped splice: $(embedDir $ profilerDir </> "css")
```

This PR changes our use of `embedFile`/`embedDir` to refer to paths relative to the project directory, so things build the same regardless of the current working directory of the compilation context.
