### PR TITLE
Bundle `crucible-llvm` symio-related overrides (`open`, `close`, `read`, `write`)

### DIFF
--- a/doc/overrides.md
+++ b/doc/overrides.md
@@ -246,6 +246,10 @@ signatures:
 - `i64 @labs( i64 )`
 - `i64 @llabs( i64 )`
 - `i32 @__cxa_atexit( void (i8*)*, i8*, i8* )`
+- `i32 @open( i8*, i32 )`
+- `i32 @close( i32 )`
+- `ssize_t @read( i32, i8*, size_t )`
+- `ssize_t @write( i32, i8*, size_t )`
 
 For LLVM programs (but not binaries), the following built-in overrides are also
 available:
@@ -338,6 +342,7 @@ schema:
 - `<<LANES> x i<N>>`: (there is no syntax for this Crucible type)
 - `ptr`: `(Ptr <word-size>)`
 - `size_t`: `(Ptr <word-size>)`
+- `ssize_t`: `(Ptr <word-size>)`
 - `<T>*`: `(Ptr <word-size>)`
 - `void`: `Unit`
 
@@ -368,6 +373,16 @@ The following overrides merit a bit of discussion:
   Allocate a fresh pointer of the given size in the underlying
   [memory model](./memory-model.md). This pointer is assumed not to alias with
   any pointers allocated by previous calls to `malloc`.
+
+- `open`, `close`, `read`, and `write`
+
+  These overrides leverage Crucible's experimental symbolic I/O capabilities.
+  In particular, these overrides require the use of a symbolic filesystem,
+  which must be specified with `--fs-root <path-to-filesystem-root>` when
+  invoking `grease`. See [symbolic I/O] for a more detailed description of what
+  the contents of the symbolic filesystem should look like.
+
+  [symbolic I/O]: https://github.com/GaloisInc/crucible/tree/master/crux-llvm#symbolic-io-experimental
 
 ## Startup overrides
 

--- a/doc/scripts/get-overrides.sh
+++ b/doc/scripts/get-overrides.sh
@@ -21,6 +21,7 @@ function print_overrides() {
 
 function libc_overrides() {
   print_overrides "${CRUCIBLE_LLVM_DIR}/src/Lang/Crucible/LLVM/Intrinsics/Libc.hs"
+  print_overrides "${CRUCIBLE_LLVM_DIR}/src/Lang/Crucible/LLVM/SymIO.hs"
 }
 
 function llvm_overrides() {

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -159,6 +159,7 @@ library
     , crucible-llvm-debug
     , crucible-llvm-syntax
     , crucible-macaw-debug
+    , crucible-symio
     , crucible-syntax
     , elf-edit
     , llvm-pretty

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -189,6 +189,13 @@ simOpts = do
     Opt.switch ( Opt.long "rust"
                  <> Opt.help "Use simulator settings that are more likely to work for Rust programs"
                )
+  simFsRoot <-
+    Opt.optional
+          ( Opt.strOption
+            (  Opt.long "fs-root"
+            <> Opt.metavar "PATH"
+            <> Opt.help "The path to the symbolic filesystem"
+            ))
   pure GO.SimOpts{..}
     where
       allMutableGlobalStateStrs :: [String]

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -118,11 +118,16 @@ import qualified Lang.Crucible.LLVM.Intrinsics as CLLVM
 import qualified Lang.Crucible.LLVM.MemModel as Mem
 import qualified Lang.Crucible.LLVM.MemModel.Partial as Mem
 import qualified Lang.Crucible.LLVM.Globals as CLLVM
+import qualified Lang.Crucible.LLVM.SymIO as CLLVM.SymIO
 import qualified Lang.Crucible.LLVM.Translation as Trans
 import qualified Lang.Crucible.LLVM.TypeContext as TCtx
 
 -- crucible-llvm-syntax
 import Lang.Crucible.LLVM.Syntax (llvmParserHooks, emptyParserHooks)
+
+-- crucible-symio
+import qualified Lang.Crucible.SymIO as SymIO
+import qualified Lang.Crucible.SymIO.Loader as SymIO.Loader
 
 -- crucible-syntax
 import qualified Lang.Crucible.Syntax.Concrete as CSyn
@@ -487,6 +492,29 @@ interestingConcretizedShapes names initArgs (ConcArgs cArgs) =
     names
     (Ctx.zipWith (\s s' -> Const (Maybe.isJust (testEquality s s'))) cShapes initArgs')
 
+-- | Helper, not exported
+--
+-- Initialize the symbolic file system.
+initialLlvmFileSystem ::
+  ( C.IsSymInterface sym
+  , Mem.HasPtrWidth ptrW
+  ) =>
+  C.HandleAllocator ->
+  sym ->
+  SimOpts ->
+  IO ( CLLVM.SymIO.LLVMFileSystem ptrW
+     , C.SymGlobalState sym
+     , CLLVM.SymIO.SomeOverrideSim sym ()
+     )
+initialLlvmFileSystem halloc sym simOpts = do
+  fileContents <-
+    case simFsRoot simOpts of
+      Nothing -> pure SymIO.emptyInitialFileSystemContents
+      Just fsRoot -> SymIO.Loader.loadInitialFiles sym fsRoot
+  -- We currently don't mirror stdout or stderr
+  let mirroredOutputs = []
+  CLLVM.SymIO.initialLLVMFileSystem halloc sym ?ptrWidth fileContents mirroredOutputs C.emptyGlobals
+
 simulateMacawCfg ::
   forall sym bak arch solver scope st fm.
   ( C.IsSymBackend sym bak
@@ -607,7 +635,8 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook mbCfg
         m (C.ExecState (GreaseSimulatorState sym arch) sym (Symbolic.MacawExt arch) (C.RegEntry sym (C.StructType (Symbolic.MacawCrucibleRegTypes arch))))
       mkInitState regs' mem' ssa'@(C.SomeCFG ssaCfg') = do
         mvar <- liftIO $ Mem.mkMemVar "grease:memmodel" halloc
-        let builtinOvs = builtinStubsOverrides bak mvar memCfg0 archCtx
+        (fs, globals, initFsOv) <- liftIO $ initialLlvmFileSystem halloc sym simOpts
+        let builtinOvs = builtinStubsOverrides bak mvar memCfg0 archCtx fs
         fnOvsMap <- liftIO $ Macaw.mkMacawOverrideMap bak builtinOvs userOvPaths halloc mvar archCtx
         let memCfg1 = memConfigWithHandles bak la halloc archCtx memory symMap pltStubs dynFunMap fnOvsMap builtinGenericSyscalls errorSymbolicFunCalls memCfg0
         evalFn <- Symbolic.withArchEval @Symbolic.LLVMMemory @arch (archCtx ^. archVals) sym pure
@@ -620,7 +649,7 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook mbCfg
         -- use an empty map instead. (See gitlab#118 for more discussion on this point.)
         let discoveredHdls = Maybe.maybe Map.empty (`Map.singleton` ssaCfgHdl) mbCfgAddr
         let personality = emptyGreaseSimulatorState & discoveredFnHandles .~ discoveredHdls
-        initState bak la macawExtImpl halloc mvar mem' C.emptyGlobals archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
+        initState bak la macawExtImpl halloc mvar mem' globals initFsOv archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
 
   doLog la (Diag.TargetCFG ssaCfg)
   result <- refinementLoop la (simMaxIters simOpts) (simTimeout simOpts) rNamesAssign' initArgs $ \argShapes -> do
@@ -1067,6 +1096,8 @@ simulateLlvmCfg ::
   C.SomeCFG CLLVM.LLVM argTys ret ->
   IO BatchStatus
 simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCfg scfg@(C.SomeCFG cfg) = do
+  let sym = C.backendGetSym bak
+
   doLog la (Diag.TargetCFG cfg)
 
   profFeatLog <-
@@ -1097,7 +1128,8 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
     let ?recordLLVMAnnotation = \callStack (Mem.BoolAnn ann) bb ->
           modifyIORef bbMapRef $ Map.insert ann (callStack, bb)
     let llvmExtImpl = CLLVM.llvmExtensionImpl ?memOpts
-    st <- LLVM.initState bak la llvmExtImpl halloc (simErrorSymbolicFunCalls simOpts) setupMem C.emptyGlobals llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
+    (fs, globals, initFsOv) <- liftIO $ initialLlvmFileSystem halloc sym simOpts
+    st <- LLVM.initState bak la llvmExtImpl halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
     let cmdExt = Debug.llvmCommandExt
     debuggerFeat <-
       liftIO $
@@ -1228,10 +1260,10 @@ simulateLlvmSyntax simOpts la = do
         , Trans.llvmFunctionAliases = Map.empty
         }
   let setupHook :: forall sym. LLVM.SetupHook sym
-      setupHook = LLVM.SetupHook $ \bak halloc' llvmCtx' -> do
+      setupHook = LLVM.SetupHook $ \bak halloc' llvmCtx' fs -> do
         -- Register built-in and user overrides.
         funOvs <-
-          LLVM.registerLLVMSexpOverrides la builtinLLVMOverrides (simOverrides simOpts) bak halloc' llvmCtx' prog
+          LLVM.registerLLVMSexpOverrides la (builtinLLVMOverrides fs) (simOverrides simOpts) bak halloc' llvmCtx' fs prog
 
         -- In addition to binding function handles for the user overrides,
         -- we must also redirect function handles resulting from parsing
@@ -1326,7 +1358,7 @@ simulateLlvm transOpts simOpts la = do
 
     let dl = TCtx.llvmDataLayout (llvmCtxt ^. Trans.llvmTypeCtx)
     let setupHook :: forall sym. LLVM.SetupHook sym
-        setupHook = LLVM.SetupHook $ \bak halloc' llvmCtx -> do
+        setupHook = LLVM.SetupHook $ \bak halloc' llvmCtx fs -> do
           -- Register defined functions...
           let handleTranslationWarning warn = doLog la (Diag.LLVMTranslationWarning warn)
           Trans.llvmPtrWidth llvmCtxt $ \ptrW' -> Mem.withPtrWidth ptrW' $
@@ -1335,7 +1367,7 @@ simulateLlvm transOpts simOpts la = do
           -- registering defined functions so that overrides take precedence over
           -- defined functions.
           funOvs <-
-            LLVM.registerLLVMModuleOverrides la builtinLLVMOverrides (simOverrides simOpts) bak halloc' llvmCtx llvmMod
+            LLVM.registerLLVMModuleOverrides la (builtinLLVMOverrides fs) (simOverrides simOpts) bak halloc' llvmCtx fs llvmMod
           -- If a startup override exists and it contains forward declarations,
           -- redirect then we redirect the function handles to actually call the
           -- respective overrides.

--- a/grease/src/Grease/FunctionOverride.hs
+++ b/grease/src/Grease/FunctionOverride.hs
@@ -61,6 +61,7 @@ import qualified Lang.Crucible.LLVM.Intrinsics.Libc as Libc
 import qualified Lang.Crucible.LLVM.Intrinsics.LLVM as LLVM
 import qualified Lang.Crucible.LLVM.MemModel as Mem
 import qualified Lang.Crucible.LLVM.Printf as Printf
+import qualified Lang.Crucible.LLVM.SymIO as SymIO
 import qualified Lang.Crucible.LLVM.TypeContext as TCtx
 
 -- what4
@@ -100,8 +101,9 @@ builtinStubsOverrides ::
   C.GlobalVar Mem.Mem ->
   Symbolic.MemModelConfig p sym arch Mem.Mem ->
   ArchContext arch ->
+  SymIO.LLVMFileSystem (MC.ArchAddrWidth arch) ->
   Seq.Seq (Stubs.SomeFunctionOverride p sym arch)
-builtinStubsOverrides bak mvar mmConf archCtx =
+builtinStubsOverrides bak mvar mmConf archCtx fs =
   customOvs <> fromLlvmOvs
   where
     -- Custom overrides that are only applicable at the machine code level (and
@@ -134,7 +136,7 @@ builtinStubsOverrides bak mvar mmConf archCtx =
         (\(Mem.SomeLLVMOverride ov) ->
           L.decName (Mem.llvmOverride_declare ov) `Set.notMember`
           excludedLibcOverrides)
-        Libc.libc_overrides
+        (libcOverrides fs)
 
     -- Overrides that we do not want to use at the binary level. If you add an
     -- override to this list, make sure to include a comment with the reason why
@@ -161,21 +163,51 @@ builtinStubsOverrides bak mvar mmConf archCtx =
 -- This does not include \"polymorphic\" overrides, see 'builtinLLVMOverrides'
 -- for those.
 basicLLVMOverrides ::
+  forall p sym ext w.
   ( C.IsSymInterface sym
   , ?lc :: TCtx.TypeContext
   , ?memOpts :: Mem.MemOptions
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth w
   ) =>
+  SymIO.LLVMFileSystem w ->
   Seq.Seq (Mem.SomeLLVMOverride p sym ext)
-basicLLVMOverrides =
+basicLLVMOverrides fs =
   -- We never need to make use of any non-standard IntrinsicsOptions.
   let ?intrinsicsOpts = Mem.defaultIntrinsicsOptions in
   Seq.fromList $
     List.concat @[]
-    [ Libc.libc_overrides
+    [ libcOverrides fs
     , LLVM.basic_llvm_overrides
     ]
+
+-- | Helper, not exported
+--
+-- LLVM overrides corresponding to functions defined in @libc@.
+libcOverrides ::
+  forall p sym ext w.
+  ( C.IsSymInterface sym
+  , ?lc :: TCtx.TypeContext
+  , ?memOpts :: Mem.MemOptions
+  , ?intrinsicsOpts :: Mem.IntrinsicsOptions
+  , Mem.HasLLVMAnn sym
+  , Mem.HasPtrWidth w
+  ) =>
+  SymIO.LLVMFileSystem w ->
+  [Mem.SomeLLVMOverride p sym ext]
+libcOverrides fs =
+  List.concat @[]
+    [ Libc.libc_overrides
+    , symioLlvmOverrides
+    ]
+  where
+    symioLlvmOverrides :: [Mem.SomeLLVMOverride p sym ext]
+    symioLlvmOverrides =
+      [ Mem.SomeLLVMOverride $ SymIO.openFile fs
+      , Mem.SomeLLVMOverride $ SymIO.closeFile fs
+      , Mem.SomeLLVMOverride $ SymIO.readFileHandle fs
+      , Mem.SomeLLVMOverride $ SymIO.writeFileHandle fs
+      ]
 
 -- | All of the @crucible-llvm@ overrides that work across all supported
 -- configurations.
@@ -189,11 +221,12 @@ builtinLLVMOverrides ::
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth w
   ) =>
+  SymIO.LLVMFileSystem w ->
   Seq.Seq (Mem.OverrideTemplate p sym ext arch)
-builtinLLVMOverrides =
+builtinLLVMOverrides fs =
   -- We never need to make use of any non-standard IntrinsicsOptions.
   let ?intrinsicsOpts = Mem.defaultIntrinsicsOptions in
-  fmap (\(Mem.SomeLLVMOverride ov) -> Mem.basic_llvm_override ov) basicLLVMOverrides
+  fmap (\(Mem.SomeLLVMOverride ov) -> Mem.basic_llvm_override ov) (basicLLVMOverrides fs)
     <> Seq.fromList (List.map (\(pfx, LLVM.Poly1LLVMOverride ov) -> Mem.polymorphic1_llvm_override pfx ov) LLVM.poly1_llvm_overrides)
 
 -----

--- a/grease/src/Grease/Options.hs
+++ b/grease/src/Grease/Options.hs
@@ -112,6 +112,8 @@ data SimOpts
     , simSolver :: Solver
       -- | Timeout (implemented using 'timeout')
     , simTimeout :: Milliseconds
+      -- | File system root
+    , simFsRoot :: Maybe FilePath
     }
   deriving Show
 


### PR DESCRIPTION
This requires some additional plumbing to thread out the various bits of data that these overrides require (e.g., an `LLVMFileSystem` value), but otherwise this proves straightforward.

Fixes #139.