### PR TITLE
Swap gitrev with githash

### DIFF
--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -135,7 +135,7 @@ library
     , exceptions ^>= 0.10.5
     , file-embed ^>= 0.0.16
     , filepath ^>= 1.4.2.2
-    , gitrev ^>= 1.3
+    , githash ^>=0.1.7.0
     , lens ^>= 5.3
     , libBF ^>= 0.6.8
     , lumberjack ^>= { 1.0, 1.1 }

--- a/grease/src/Grease/GitRev.hs
+++ b/grease/src/Grease/GitRev.hs
@@ -1,24 +1,29 @@
-{-|
-Copyright        : (c) Galois, Inc. 2024
-Maintainer       : GREASE Maintainers <grease@galois.com>
--}
-
 {-# LANGUAGE TemplateHaskell #-}
 
--- | These are placed in their own module to minimize the cost of recompilation
+-- \| These are placed in their own module to minimize the cost of recompilation
 -- due to Template Haskell.
+
+-- |
+-- Copyright        : (c) Galois, Inc. 2024
+-- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.GitRev (hash, branch, dirty) where
 
-import GitHash (GitInfo, tGitInfoCwd, giHash, giBranch, giDirty)
+import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)
 
-gitInfo :: GitInfo
-gitInfo = $$tGitInfoCwd
+gitInfo :: Either String GitInfo
+gitInfo = $$tGitInfoCwdTry
 
 hash :: String
-hash = giHash gitInfo
+hash = case gitInfo of
+    Left _ -> "UNKNOWN"
+    Right gi -> giHash gi
 
 branch :: String
-branch = giBranch gitInfo
+branch = case gitInfo of
+    Left _ -> "UNKNOWN"
+    Right gi -> giBranch gi
 
 dirty :: Bool
-dirty = giDirty gitInfo
+dirty = case gitInfo of
+  Left _ -> False
+  Right gi -> giDirty gi

--- a/grease/src/Grease/GitRev.hs
+++ b/grease/src/Grease/GitRev.hs
@@ -1,10 +1,11 @@
+{-|
+Copyright        : (c) Galois, Inc. 2024
+Maintainer       : GREASE Maintainers <grease@galois.com>
+-}
+
 {-# LANGUAGE TemplateHaskell #-}
 
--- |
--- Copyright        : (c) Galois, Inc. 2024
--- Maintainer       : GREASE Maintainers <grease@galois.com>
---
--- These are placed in their own module to minimize the cost of recompilation
+-- | These are placed in their own module to minimize the cost of recompilation
 -- due to Template Haskell.
 module Grease.GitRev (hash, branch, dirty) where
 

--- a/grease/src/Grease/GitRev.hs
+++ b/grease/src/Grease/GitRev.hs
@@ -1,11 +1,11 @@
 {-# LANGUAGE TemplateHaskell #-}
 
--- \| These are placed in their own module to minimize the cost of recompilation
--- due to Template Haskell.
-
 -- |
 -- Copyright        : (c) Galois, Inc. 2024
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
+--
+-- These are placed in their own module to minimize the cost of recompilation
+-- due to Template Haskell.
 module Grease.GitRev (hash, branch, dirty) where
 
 import GitHash (GitInfo, giBranch, giDirty, giHash, tGitInfoCwdTry)

--- a/grease/src/Grease/GitRev.hs
+++ b/grease/src/Grease/GitRev.hs
@@ -9,13 +9,16 @@ Maintainer       : GREASE Maintainers <grease@galois.com>
 -- due to Template Haskell.
 module Grease.GitRev (hash, branch, dirty) where
 
-import Development.GitRev (gitBranch, gitDirty, gitHash)
+import GitHash (GitInfo, tGitInfoCwd, giHash, giBranch, giDirty)
+
+gitInfo :: GitInfo
+gitInfo = $$tGitInfoCwd
 
 hash :: String
-hash = $(gitHash)
+hash = giHash gitInfo
 
 branch :: String
-branch = $(gitBranch)
+branch = giBranch gitInfo
 
 dirty :: Bool
-dirty = $(gitDirty)
+dirty = giDirty gitInfo


### PR DESCRIPTION
Resolve #116 

I picked up `githash` to avoid raising bound for dependencies
( `gitrev-typed` draws new `filepath`).