### PR TITLE
`ResolveCall`: Add `Lookup{FunctionHandle,Syscall}Dispatch`

### DIFF
--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -458,7 +458,7 @@ memConfigWithHandles bak logAction halloc arch memory symMap pltStubs dynFunMap 
   , Symbolic.lookupSyscallHandle = ResolveCall.lookupSyscallHandle bak arch syscallOvs lsd
   }
   where
-    lfhd = ResolveCall.defaultLookupFunctionHandleDispatch bak logAction halloc arch funOvs
+    lfhd = ResolveCall.defaultLookupFunctionHandleDispatch bak logAction halloc arch memory funOvs
     lsd = ResolveCall.defaultLookupSyscallDispatch bak logAction halloc arch
 
 -- | Check whether a pointer points to a relocation address, and if so, assert

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -60,7 +60,7 @@ import Grease.Diagnostic
 import Grease.Macaw.Arch
 import Grease.Macaw.FunctionOverride
 import Grease.Macaw.Load.Relocation (RelocType(..))
-import Grease.Macaw.ResolveCall (lookupFunctionHandle, lookupSyscallHandle)
+import Grease.Macaw.ResolveCall qualified as ResolveCall
 import Grease.Macaw.SimulatorHooks
 import Grease.Macaw.SimulatorState
 import Grease.Options qualified as Opts
@@ -454,9 +454,11 @@ memConfigWithHandles ::
   Symbolic.MemModelConfig p sym arch Mem.Mem
 memConfigWithHandles bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs syscallOvs errorSymbolicFunCalls memCfg =
   memCfg
-  { Symbolic.lookupFunctionHandle = lookupFunctionHandle bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls
-  , Symbolic.lookupSyscallHandle = lookupSyscallHandle bak logAction halloc arch syscallOvs
+  { Symbolic.lookupFunctionHandle = ResolveCall.lookupFunctionHandle bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls
+  , Symbolic.lookupSyscallHandle = ResolveCall.lookupSyscallHandle bak arch syscallOvs lsd
   }
+  where
+    lsd = ResolveCall.defaultLookupSyscallDispatch bak logAction halloc arch
 
 -- | Check whether a pointer points to a relocation address, and if so, assert
 -- that the underlying relocation type is supported. If not, throw an exception.

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -454,10 +454,11 @@ memConfigWithHandles ::
   Symbolic.MemModelConfig p sym arch Mem.Mem
 memConfigWithHandles bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs syscallOvs errorSymbolicFunCalls memCfg =
   memCfg
-  { Symbolic.lookupFunctionHandle = ResolveCall.lookupFunctionHandle bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls
+  { Symbolic.lookupFunctionHandle = ResolveCall.lookupFunctionHandle bak logAction halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls lfhd
   , Symbolic.lookupSyscallHandle = ResolveCall.lookupSyscallHandle bak arch syscallOvs lsd
   }
   where
+    lfhd = ResolveCall.defaultLookupFunctionHandleDispatch bak logAction halloc arch funOvs
     lsd = ResolveCall.defaultLookupSyscallDispatch bak logAction halloc arch
 
 -- | Check whether a pointer points to a relocation address, and if so, assert

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -247,7 +247,8 @@ lookupFunctionHandle ::
   ErrorSymbolicFunCalls ->
   LookupFunctionHandleDispatch p sym arch ->
   Symbolic.LookupFunctionHandle p sym arch
-lookupFunctionHandle bak la halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls (LookupFunctionHandleDispatch dispatch) = Symbolic.LookupFunctionHandle $ \st mem regs -> do
+lookupFunctionHandle bak la halloc arch memory symMap pltStubs dynFunMap funOvs errorSymbolicFunCalls lfhd = Symbolic.LookupFunctionHandle $ \st mem regs -> do
+  let LookupFunctionHandleDispatch dispatch = lfhd
   let dispatch' st' = dispatch st' mem regs
 
   -- First, obtain the address contained in the instruction pointer.
@@ -442,8 +443,9 @@ lookupSyscallHandle ::
   -- | Dispatch on the result of looking up a syscall override.
   LookupSyscallDispatch p sym arch ->
   Symbolic.LookupSyscallHandle p sym arch
-lookupSyscallHandle bak arch syscallOvs (LookupSyscallDispatch dispatch) =
+lookupSyscallHandle bak arch syscallOvs lsd =
   Symbolic.LookupSyscallHandle $ \atps rtps st regs -> do
+    let LookupSyscallDispatch dispatch = lsd
     let dispatch' = dispatch atps rtps st regs
     symSyscallBV <- (arch ^. archSyscallNumberRegister) bak atps regs
 

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -43,7 +43,7 @@ import Grease.Macaw.Discovery (discoverFunction)
 import Grease.Macaw.FunctionOverride
 import Grease.Macaw.ResolveCall.Diagnostic qualified as Diag
 import Grease.Macaw.SimulatorState
-import Grease.Macaw.SkippedCall (SkippedCall(..))
+import Grease.Macaw.SkippedCall (SkippedFunctionCall(..), SkippedSyscall(..))
 import Grease.Macaw.Syscall
 import Grease.Options (ErrorSymbolicFunCalls(..))
 import Grease.Utility (declaredFunNotFound)
@@ -146,7 +146,7 @@ lookupFunctionHandle bak la halloc arch memory symMap pltStubs dynFunMap funOvs 
 
   let -- Treat an external function as a no-op during simulation.
       skipExternalCall reason = do
-        doLog la $ Diag.SkippedCall reason
+        doLog la $ Diag.SkippedFunctionCall reason
         let funcName = W4.functionNameFromText "_grease_external"
         handle <- C.mkHandle' halloc funcName (Ctx.Empty Ctx.:> regStructRepr arch) (regStructRepr arch)
         let override = C.mkOverride' funcName (regStructRepr arch) $ do
@@ -264,7 +264,7 @@ lookupSyscallHandle bak la halloc arch syscallOvs = Symbolic.LookupSyscallHandle
 
   let -- Treat this syscall as a no-op during simulation.
       skipCall reason = do
-        doLog la $ Diag.SkippedCall reason
+        doLog la $ Diag.SkippedSyscall reason
         let funcName = W4.functionNameFromText "_grease_syscall"
         handle <- C.mkHandle' halloc funcName atps (C.StructRepr rtps)
         let override =

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -21,6 +21,9 @@ module Grease.Macaw.ResolveCall
   , LookupSyscallDispatch(..)
   , defaultLookupSyscallDispatch
   , LookupSyscallResult(..)
+
+    -- * Helper functions for looking up handles
+  , discoverFuncAddr
   ) where
 
 import Control.Applicative (pure)

--- a/grease/src/Grease/Macaw/ResolveCall/Diagnostic.hs
+++ b/grease/src/Grease/Macaw/ResolveCall/Diagnostic.hs
@@ -45,8 +45,10 @@ data Diagnostic where
     Text {- ^ Syscall name -} ->
     Int {- ^ Syscall number -} ->
     Diagnostic
-  SkippedCall ::
-    Skip.SkippedCall arch -> Diagnostic
+  SkippedFunctionCall ::
+    Skip.SkippedFunctionCall arch -> Diagnostic
+  SkippedSyscall ::
+    Skip.SkippedSyscall -> Diagnostic
 
 instance PP.Pretty Diagnostic where
   pretty d =
@@ -71,7 +73,8 @@ instance PP.Pretty Diagnostic where
       SyscallOverride name num ->
         "Using an override for the" PP.<+> PP.pretty name PP.<+>
         PP.parens (PP.pretty num) PP.<+> "syscall"
-      SkippedCall call -> PP.pretty call
+      SkippedFunctionCall call -> PP.pretty call
+      SkippedSyscall call -> PP.pretty call
 
 severity :: Diagnostic -> Severity
 severity =
@@ -80,4 +83,5 @@ severity =
     FunctionCall{} -> Debug
     FunctionOverride{} -> Debug
     SyscallOverride{} -> Debug
-    SkippedCall{} -> Info
+    SkippedFunctionCall{} -> Info
+    SkippedSyscall{} -> Info

--- a/grease/src/Grease/Macaw/SkippedCall.hs
+++ b/grease/src/Grease/Macaw/SkippedCall.hs
@@ -36,7 +36,7 @@ data SkippedFunctionCall arch where
     MemSegmentOff (MC.ArchAddrWidth arch) ->
     SkippedFunctionCall arch
 
--- | The reasons that GREASE might skip a function call
+-- | The reasons that GREASE might skip a syscall
 data SkippedSyscall where
   SymbolicSyscallNumber ::
     SkippedSyscall


### PR DESCRIPTION
This makes the API in `Grease.Macaw.ResolveCall` more extensible by parameterizing the behavior of the `lookupFunctionHandle` and `lookupSyscallHandle` functions by continuations that allow the user to control how functions or syscalls are simulated. The key data types are:

* `Lookup{FunctionHandle,Syscall}Dispatch`: newtypes around the continuations themselves
* `Lookup{FunctionHandle,Syscall}Result`: a data type that captures the result of resolving the function/syscall

Fixes #179.