### PR TITLE
Add `fresh-bytes` override for S-expression CFGs

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -203,6 +203,11 @@ available:
 
 ### S-expression-specific overrides
 
+For S-expression files (programs or overrides), the following overrides are also available:
+```
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector w))) (Vector (Bitvector 8)))
+```
+
 For LLVM S-expression files (programs or overrides), the following overrides are also available:
 ```
 (declare @read-bytes ((x (Ptr 64))) (Vector (Bitvector 8)))

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -203,9 +203,31 @@ available:
 
 ### S-expression-specific overrides
 
-For S-expression files (programs or overrides), the following overrides are also available:
+For S-expression files (programs or overrides), the following override is also available:
 ```
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector w))) (Vector (Bitvector 8)))
+```
+
+The bytes created using `fresh-bytes` will be concretized and printed to the
+terminal if GREASE finds a possible bug. `fresh-bytes` can be used to create
+overrides for functions that do I/O, such as the following basic override for
+`recv`:
+```
+; Basic override for `recv`.
+;
+; Ignores `socket` and `flags`. Always reads exactly `length` bytes.
+
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+
+; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
+(defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
+  (start start:
+    (let length-bv (ptr-offset 64 length))
+    (let bytes (funcall @fresh-bytes "recv" length-bv))
+    (let byte (vector-get bytes 0))
+    (let byte-ptr (ptr 8 0 byte))
+    (store none i8 buffer byte-ptr)
+    (return length)))
 ```
 
 For LLVM S-expression files (programs or overrides), the following overrides are also available:

--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -203,42 +203,21 @@ available:
 
 ### S-expression-specific overrides
 
-For S-expression files (programs or overrides), the following override is also available:
+The following overrides are only available in S-expression files (programs or overrides).
+See [Writing S-expression programs](sexp.md) for more details.
+
 ```
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector w))) (Vector (Bitvector 8)))
 ```
 
-The bytes created using `fresh-bytes` will be concretized and printed to the
-terminal if GREASE finds a possible bug. `fresh-bytes` can be used to create
-overrides for functions that do I/O, such as the following basic override for
-`recv`:
-```
-; Basic override for `recv`.
-;
-; Ignores `socket` and `flags`. Always reads exactly `length` bytes.
-
-(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
-
-; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
-(defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
-  (start start:
-    (let length-bv (ptr-offset 64 length))
-    (let bytes (funcall @fresh-bytes "recv" length-bv))
-    (let byte (vector-get bytes 0))
-    (let byte-ptr (ptr 8 0 byte))
-    (store none i8 buffer byte-ptr)
-    (return length)))
-```
-
-For LLVM S-expression files (programs or overrides), the following overrides are also available:
+For LLVM S-expression files (programs or overrides), the following overrides are
+also available:
 ```
 (declare @read-bytes ((x (Ptr 64))) (Vector (Bitvector 8)))
 (declare @read-c-string ((x (Ptr 64))) (String Unicode))
 (declare @write-bytes ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
 (declare @write-c-string ((dst (Ptr 64)) (src (String Unicode))) Unit)
 ```
-
-See [the upstream documentation](https://github.com/GaloisInc/crucible/blob/master/crucible-llvm-syntax/README.md#string-manipulation).
 
 ### Discussion
 

--- a/doc/sexp.md
+++ b/doc/sexp.md
@@ -52,3 +52,45 @@ values in `R0` and `R1`:
 For more information about this struct, see [the Macaw documentation].
 
 [the Macaw documentation]: https://github.com/GaloisInc/macaw/blob/master/doc/Design.md#translation
+
+## S-expression-specific Overrides
+
+There are a few overrides that are only available in S-expression files
+(programs or overrides).
+```
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector w))) (Vector (Bitvector 8)))
+```
+
+The bytes created using `fresh-bytes` will be concretized and printed to the
+terminal if GREASE finds a possible bug. `fresh-bytes` can be used to create
+overrides for functions that do I/O, such as the following basic override for
+`recv`:
+```
+; Basic override for `recv`.
+;
+; Ignores `socket` and `flags`. Always reads exactly `length` bytes.
+
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+
+; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
+(defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
+  (start start:
+    (let length-bv (ptr-offset 64 length))
+    (let bytes (funcall @fresh-bytes "recv" length-bv))
+    (let byte (vector-get bytes 0))
+    (let byte-ptr (ptr 8 0 byte))
+    (store none i8 buffer byte-ptr)
+    (return length)))
+```
+
+### LLVM-specific overrides
+
+For LLVM S-expression files (programs or overrides), the following overrides are also available:
+```
+(declare @read-bytes ((x (Ptr 64))) (Vector (Bitvector 8)))
+(declare @read-c-string ((x (Ptr 64))) (String Unicode))
+(declare @write-bytes ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
+(declare @write-c-string ((dst (Ptr 64)) (src (String Unicode))) Unit)
+```
+
+See [the upstream documentation](https://github.com/GaloisInc/crucible/blob/master/crucible-llvm-syntax/README.md#string-manipulation).

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -218,7 +218,7 @@ test-suite grease-tests
     , hedgehog ^>= 1.5
     , hslua ^>= 2.3.1
     , lumberjack ^>= 1.0
-    , oughta ^>= 0.2
+    , oughta ^>= 0.3
     , parameterized-utils ^>= 2.1.10
     , prettyprinter ^>= 1.7.1
     , tasty ^>= 1.5.3

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -102,6 +102,7 @@ import Grease.Bug qualified as Bug
 import Grease.Cli (optsFromArgs)
 import Grease.Concretize (ConcretizedData, ConcArgs(..))
 import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Concretize.JSON (concArgsToJson)
 import Grease.Cursor.Pointer ()
 import Grease.Diagnostic
@@ -1129,7 +1130,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
 
   profFeatLog <-
     traverse
-      (greaseProfilerFeature @(C.GlobalVar Conc.ToConcretizeType) @sym @CLLVM.LLVM @(C.RegEntry sym ret))
+      (greaseProfilerFeature @(C.GlobalVar ToConc.ToConcretizeType) @sym @CLLVM.LLVM @(C.RegEntry sym ret))
       (simProfileTo simOpts)
 
   C.Refl <-

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -1123,7 +1123,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
 
   profFeatLog <-
     traverse
-      (greaseProfilerFeature @() @sym @CLLVM.LLVM @(C.RegEntry sym ret))
+      (greaseProfilerFeature @(Conc.ToConcretize sym) @sym @CLLVM.LLVM @(C.RegEntry sym ret))
       (simProfileTo simOpts)
 
   C.Refl <-
@@ -1150,7 +1150,8 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
           modifyIORef bbMapRef $ Map.insert ann (callStack, bb)
     let llvmExtImpl = CLLVM.llvmExtensionImpl ?memOpts
     (fs0, fs, globals, initFsOv) <- liftIO $ initialLlvmFileSystem halloc sym simOpts
-    st <- LLVM.initState bak la llvmExtImpl halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
+    let p = Conc.ToConcretize []  -- personality
+    st <- LLVM.initState bak la llvmExtImpl p halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
     let cmdExt = Debug.llvmCommandExt
     debuggerFeat <-
       liftIO $

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -171,9 +171,7 @@ import Lang.Crucible.SymIO qualified as SymIO
 import Lang.Crucible.SymIO.Loader qualified as SymIO.Loader
 import Lang.Crucible.LLVM.TypeContext qualified as TCtx
 import Lang.Crucible.Simulator qualified as C
-import Lang.Crucible.Simulator.GlobalState qualified as C
 import Lang.Crucible.Simulator.SimError qualified as C
-import Lang.Crucible.Simulator.SymSequence qualified as C
 import Lang.Crucible.Syntax.Concrete qualified as CSyn
 import Lang.Crucible.Syntax.Prog qualified as CSyn
 import Lumberjack qualified as LJ
@@ -634,8 +632,7 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook mbCfg
         -- Grease.Macaw.SimulatorState.) If we are simulating an S-expression program,
         -- use an empty map instead. (See gitlab#118 for more discussion on this point.)
         let discoveredHdls = Maybe.maybe Map.empty (`Map.singleton` ssaCfgHdl) mbCfgAddr
-        toConcVar <- liftIO (C.freshGlobalVar halloc "to-concretize" W4.knownRepr)
-        let globals1 = C.insertGlobal toConcVar C.SymSequenceNil globals0
+        (toConcVar, globals1) <- liftIO $ ToConc.newToConcretize halloc globals0
         let personality =
               emptyGreaseSimulatorState toConcVar &
                 discoveredFnHandles .~ discoveredHdls
@@ -1157,8 +1154,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
           modifyIORef bbMapRef $ Map.insert ann (callStack, bb)
     let llvmExtImpl = CLLVM.llvmExtensionImpl ?memOpts
     (fs0, fs, globals0, initFsOv) <- liftIO $ initialLlvmFileSystem halloc sym simOpts
-    p <- C.freshGlobalVar halloc "to-concretize" W4.knownRepr
-    let globals1 = C.insertGlobal p C.SymSequenceNil globals0
+    (p, globals1) <- liftIO $ ToConc.newToConcretize halloc globals0
     st <- LLVM.initState bak la llvmExtImpl p halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals1 initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
     let cmdExt = Debug.llvmCommandExt
     debuggerFeat <-

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -634,11 +634,11 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook mbCfg
         -- use an empty map instead. (See gitlab#118 for more discussion on this point.)
         let discoveredHdls = Maybe.maybe Map.empty (`Map.singleton` ssaCfgHdl) mbCfgAddr
         toConcVar <- liftIO (C.freshGlobalVar halloc "to-concretize" W4.knownRepr)
-        let globals = C.insertGlobal toConcVar C.SymSequenceNil globals0
+        let globals1 = C.insertGlobal toConcVar C.SymSequenceNil globals0
         let personality =
               emptyGreaseSimulatorState toConcVar &
                 discoveredFnHandles .~ discoveredHdls
-        st <- initState bak la macawExtImpl halloc mvar mem' globals initFsOv archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
+        st <- initState bak la macawExtImpl halloc mvar mem' globals1 initFsOv archCtx memPtrTable setupHook personality regs' fnOvsMap mbStartupOvSsaCfg ssa'
         pure (fs0, st)
 
   doLog la (Diag.TargetCFG ssaCfg)
@@ -1157,8 +1157,8 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx initMem setupHook mbStartupOvCf
     let llvmExtImpl = CLLVM.llvmExtensionImpl ?memOpts
     (fs0, fs, globals0, initFsOv) <- liftIO $ initialLlvmFileSystem halloc sym simOpts
     p <- C.freshGlobalVar halloc "to-concretize" W4.knownRepr
-    let globals = C.insertGlobal p C.SymSequenceNil globals0
-    st <- LLVM.initState bak la llvmExtImpl p halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
+    let globals1 = C.insertGlobal p C.SymSequenceNil globals0
+    st <- LLVM.initState bak la llvmExtImpl p halloc (simErrorSymbolicFunCalls simOpts) setupMem fs globals1 initFsOv llvmCtx setupHook (argVals args) mbStartupOvCfg scfg
     let cmdExt = Debug.llvmCommandExt
     debuggerFeat <-
       liftIO $

--- a/grease-cli/tests/arm/fresh-bytes.armv7l.cbl
+++ b/grease-cli/tests/arm/fresh-bytes.armv7l.cbl
@@ -1,0 +1,16 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that `fresh-bytes` is registered.
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 32))) (Vector (Bitvector 8)))
+
+(defun @test ((regs AArch32Regs)) AArch32Regs
+  (start start:
+    (let _ (funcall @fresh-bytes "test" (bv 32 2)))
+    (return regs)))
+
+;; ok()

--- a/grease-cli/tests/llvm/branch-fresh-bytes.llvm.cbl
+++ b/grease-cli/tests/llvm/branch-fresh-bytes.llvm.cbl
@@ -20,5 +20,5 @@
     (funcall @abort)
     (return ())))
 
-; TODO: Check that the bytes are *not* in the output
 ;; check "Call to abort"
+;; check_not "Concretized values:"

--- a/grease-cli/tests/llvm/branch-fresh-bytes.llvm.cbl
+++ b/grease-cli/tests/llvm/branch-fresh-bytes.llvm.cbl
@@ -1,0 +1,24 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that concretized bytes from calls to `fresh-bytes` are not shown in the
+; output for bugs on other branches.
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+(declare @abort () Unit)
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+
+(defun @test ((p (Ptr 64))) Unit
+  (start start:
+    (let off (ptr-offset 64 p))
+    (branch (equal? off (bv 64 0)) if: else:))
+  (defblock if:
+    (funcall @fresh-bytes "test" (bv 64 2))
+    (return ()))
+  (defblock else:
+    (funcall @abort)
+    (return ())))
+
+; TODO: Check that the bytes are *not* in the output
+;; check "Call to abort"

--- a/grease-cli/tests/llvm/extra/recv.llvm.cbl
+++ b/grease-cli/tests/llvm/extra/recv.llvm.cbl
@@ -1,0 +1,17 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Override for `recv` that uses `fresh-bytes`.
+;
+; Ignores `socket` and `flags`, always reads exactly `length` bytes.
+
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+
+; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
+(defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
+  (start start:
+    (let length-bv (ptr-offset 64 length))
+    (let bytes (funcall @fresh-bytes "recv" length-bv))
+    (let byte (vector-get bytes 0))
+    (let byte-ptr (ptr 8 0 byte))
+    (store none i8 buffer byte-ptr)
+    (return length)))

--- a/grease-cli/tests/llvm/fresh-bytes.llvm.cbl
+++ b/grease-cli/tests/llvm/fresh-bytes.llvm.cbl
@@ -1,0 +1,16 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that `fresh-bytes` is registered.
+
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+
+(declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+
+(defun @test () (Vector (Bitvector 8))
+  (start start:
+    (let v (funcall @fresh-bytes "test" (bv 64 2)))
+    (return v)))
+
+;; ok()

--- a/grease-cli/tests/llvm/recv-fresh-bytes.llvm.cbl
+++ b/grease-cli/tests/llvm/recv-fresh-bytes.llvm.cbl
@@ -1,0 +1,39 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that bytes from calls to `fresh-bytes` in user-provided overrides are
+; concretized and printed, using `recv` as a realistic example.
+
+;; flags {"--overrides", "tests/llvm/extra/recv.llvm.cbl"}
+;; flags {"--symbol", "test"}
+;; go(prog)
+
+; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
+(declare @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64))
+
+(defun @test ((socket (Ptr 32))) Unit
+  (start start:
+    (let buffer (alloca none (bv 64 1)))
+    (let length (ptr 64 0 (bv 64 1)))
+    (let flags (ptr 32 0 (bv 32 0)))
+    (let r (funcall @recv socket buffer length flags))
+
+    (let off (ptr-offset 64 r))
+    (assert! (equal? off (bv 64 1)) "recv() returned something other than 1!")
+
+    (let byte (load none i8 buffer))
+    (let byte-off (ptr-offset 8 byte))
+    (branch (equal? byte-off (bv 8 0)) if: else:))
+  (defblock if:
+    (let g (resolve-global "abort"))
+    (let h (load-handle Unit () g))
+    (funcall h)
+    (return ()))
+  (defblock else:
+    (return ())))
+
+;; check "Call to abort"
+;; check [[
+;; Concretized values:
+;;   recv
+;;     00
+;; ]]

--- a/grease-cli/tests/test.lua
+++ b/grease-cli/tests/test.lua
@@ -14,17 +14,3 @@ function no_heuristic() check 'Unable to find a heuristic for any goal' end
 function req_failed() check 'One or more assertions failed' end
 
 function uninit_stack() check 'Likely bug: uninitialized stack read' end
-
--- TODO: Upstream to Oughta
-function check_not(needle)
-  if needle == "" then
-    match(0)
-    return
-  end
-  local start, _ = string.find(text, needle, 1, true)
-  if start == nil then
-    match(0)
-  else
-    fail()
-  end
-end

--- a/grease-cli/tests/test.lua
+++ b/grease-cli/tests/test.lua
@@ -14,3 +14,17 @@ function no_heuristic() check 'Unable to find a heuristic for any goal' end
 function req_failed() check 'One or more assertions failed' end
 
 function uninit_stack() check 'Likely bug: uninitialized stack read' end
+
+-- TODO: Upstream to Oughta
+function check_not(needle)
+  if needle == "" then
+    match(0)
+    return
+  end
+  local start, _ = string.find(text, needle, 1, true)
+  if start == nil then
+    match(0)
+  else
+    fail()
+  end
+end

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -180,6 +180,7 @@ library
     Grease.Bug.UndefinedBehavior
     Grease.Concretize
     Grease.Concretize.JSON
+    Grease.Concretize.ToConcretize
     Grease.Cursor
     Grease.Cursor.List
     Grease.Cursor.Pointer

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -187,6 +187,7 @@ library
     Grease.Diagnostic.Severity
     Grease.Entrypoint
     Grease.FunctionOverride
+    Grease.FunctionOverride.SExp
     Grease.Heuristic
     Grease.Heuristic.Diagnostic
     Grease.Heuristic.Result

--- a/grease/src/Grease/Concretize.hs
+++ b/grease/src/Grease/Concretize.hs
@@ -4,12 +4,14 @@ Maintainer       : GREASE Maintainers <grease@galois.com>
 -}
 
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE GADTs #-}
 
 module Grease.Concretize
   ( -- * Data to be concretized
     InitialState(..)
   , ToConcretize(..)
+  , HasToConcretize(..)
     -- * Concretization
   , ConcMem(..)
   , ConcArgs(..)
@@ -23,6 +25,7 @@ module Grease.Concretize
   , printConcData
   ) where
 
+import Control.Lens qualified as Lens
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.BitVector.Sized qualified as BV
 import Data.Foldable (toList)
@@ -75,6 +78,12 @@ data InitialState sym ext argTys
 -- concretized
 newtype ToConcretize sym
   = ToConcretize { getToConcretize :: [(Text, Some (C.RegEntry sym))] }
+
+-- | A class for Crucible personality types @p@ (see
+-- 'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality') which contain a
+-- 'ToConcretize'.
+class HasToConcretize p sym | p -> sym where
+  toConcretize :: Lens.Lens' p (ToConcretize sym)
 
 ---------------------------------------------------------------------
 -- * Concretization

--- a/grease/src/Grease/Concretize.hs
+++ b/grease/src/Grease/Concretize.hs
@@ -91,6 +91,9 @@ makeLenses ''ToConcretize
 class HasToConcretize p sym | p -> sym where
   toConcretize :: Lens.Lens' p (ToConcretize sym)
 
+instance HasToConcretize (ToConcretize sym) sym where
+  toConcretize = id
+
 -- | `Lens.Lens'` for the 'ToConcretize' in the
 -- 'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality'
 stateToConcretize ::
@@ -297,7 +300,6 @@ printConcData ::
   ConcretizedData sym ext argTys ->
   PP.Doc ann
 printConcData addrWidth argNames filt cData =
-  -- TODO: print extra concretized data
   let args = printConcArgs addrWidth argNames filt (concArgs cData)
       fs = printConcFs (concFs cData)
       extra = printConcExtra (concExtra cData)

--- a/grease/src/Grease/Concretize.hs
+++ b/grease/src/Grease/Concretize.hs
@@ -120,13 +120,13 @@ data SomeConcretizedValue sym
     , concValue :: Conc.ConcRV' sym ty
     }
 
--- | Concretized version of 'InitialState' plus 'ToConcretize'
+-- | Concretized version of 'InitialState' plus @GlobalVar 'ToConcretizeType'@
 --
 -- Produced by 'makeConcretizedData'
 data ConcretizedData sym ext argTys
   = ConcretizedData
     { concArgs :: ConcArgs sym ext argTys
-      -- | Concretized values from 'ToConcretize'
+      -- | Concretized values from the @GlobalVar 'ToConcretizeType'@
     , concExtra :: [SomeConcretizedValue sym]
     , concFs :: ConcFs
     , concMem :: ConcMem sym
@@ -138,7 +138,6 @@ makeConcretizedData ::
   OnlineSolverAndBackend solver sym bak t st fm =>
   Mem.HasPtrWidth wptr =>
   (ExtShape ext ~ PtrShape ext wptr) =>
-  (WI.SymExpr sym ~ W4.Expr t) =>
   bak ->
   W4.GroundEvalFn t ->
   Maybe (Mem.CallStack, Mem.BadBehavior sym) ->

--- a/grease/src/Grease/Concretize.hs
+++ b/grease/src/Grease/Concretize.hs
@@ -109,8 +109,7 @@ addToConcretize ::
   C.RegEntry sym ty ->
   C.OverrideSim p sym ext rtp args ret ()
 addToConcretize txt val =
-  C.stateContext . C.cruciblePersonality . toConcretize . getToConcretize Lens.%=
-    ((txt, Some val) :)
+  stateToConcretize . getToConcretize Lens.%= ((txt, Some val) :)
 
 ---------------------------------------------------------------------
 -- * Concretization

--- a/grease/src/Grease/Concretize/ToConcretize.hs
+++ b/grease/src/Grease/Concretize/ToConcretize.hs
@@ -108,7 +108,9 @@ addToConcretize name0 ent = do
     name <- liftIO (WI.stringLit sym (WI.UnicodeLiteral name0))
     let LCS.RegEntry ty val = ent
     let anyVal = LCS.AnyValue ty val
-    LCS.modifyGlobal concVar $ \toConc -> do
+    LCS.modifyGlobal concVar $ \toConc -> liftIO $ do
       let struct = Ctx.Empty Ctx.:> LCS.RV anyVal Ctx.:> LCS.RV name
-      toConc' <- liftIO (LCSS.consSymSequence sym struct toConc)
-      pure ((), toConc')
+      toConc' <- LCSS.consSymSequence sym struct toConc
+      p <- LCB.getPathCondition bak
+      toConc'' <- liftIO (LCSS.muxSymSequence sym p toConc' toConc)
+      pure ((), toConc'')

--- a/grease/src/Grease/Concretize/ToConcretize.hs
+++ b/grease/src/Grease/Concretize/ToConcretize.hs
@@ -1,0 +1,97 @@
+{-|
+Copyright        : (c) Galois, Inc. 2025
+Maintainer       : GREASE Maintainers <grease@galois.com>
+
+This module defines an interface for tracking symbolic values that are created
+during simulation (generally by overrides) and should be concretized when a
+goal fails.
+
+It stores to-be-concretized values in a Crucible global variable of type
+'ToConcretizeType'. This variable is stored in the Crucible personality (see
+'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality'), and access is
+provided via 'HasToConcretize'. TODO: Make it read-only.
+See this thread for a discussion of this choice:
+<https://github.com/GaloisInc/grease/pull/203#discussion_r2132431744>.
+-}
+
+module Grease.Concretize.ToConcretize
+  ( ToConcretizeType
+  , HasToConcretize(toConcretize)
+  , readToConcretize
+  , stateToConcretize
+  , addToConcretize
+  ) where
+
+import Control.Lens qualified as Lens
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.State.Class qualified as State
+import Data.Maybe qualified as Maybe
+import Data.Parameterized.Context qualified as Ctx
+import Data.Text (Text)
+import Lang.Crucible.Backend qualified as LCB
+import Lang.Crucible.Simulator qualified as LCS
+import Lang.Crucible.Simulator.ExecutionTree qualified as LCSE
+import Lang.Crucible.Simulator.GlobalState qualified as LCSG
+import Lang.Crucible.Simulator.SymSequence qualified as LCSS
+import Lang.Crucible.Types qualified as LCT
+import What4.Interface qualified as WI
+
+-- | The type of a global variable containing data to be concretized.
+--
+-- The first component of the struct of type 'LCT.StringType' is a name
+-- (generally expected, but not required, to be concrete), and the second
+-- component of type 'LCT.AnyType' is the value to be concretized.
+type ToConcretizeType
+  = LCT.SequenceType (LCT.StructType (Ctx.EmptyCtx Ctx.::> LCT.AnyType Ctx.::> LCT.StringType WI.Unicode))
+
+-- | A class for Crucible personality types @p@ (see
+-- 'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality') which contain a
+-- @'C.GlobalVar' 'ToConcretize'@.
+class HasToConcretize p where
+  toConcretize :: Lens.Lens' p (LCS.GlobalVar ToConcretizeType)
+
+instance HasToConcretize (LCS.GlobalVar ToConcretizeType) where
+  toConcretize = id
+
+-- | Read the value of the global variable of type 'ToConcretizeType' from
+-- a 'C.ExecResult'.
+--
+-- If the global is not present, returns 'C.SymSequenceNil'.
+readToConcretize ::
+  LCB.IsSymInterface sym =>
+  HasToConcretize p =>
+  LCS.ExecResult p sym ext r ->
+  IO (LCS.RegValue sym ToConcretizeType)
+readToConcretize result = do
+  let simCtx = LCS.execResultContext result
+  let toConcVar = simCtx Lens.^. LCS.cruciblePersonality . toConcretize
+  globs <- liftIO (LCSE.execResultGlobals result)
+  pure (Maybe.fromMaybe LCSS.SymSequenceNil (LCSG.lookupGlobal toConcVar globs))
+
+-- | `Lens.Lens'` for the 'ToConcretize' in the
+-- 'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality'
+stateToConcretize ::
+  HasToConcretize p =>
+  Lens.Lens' (LCS.SimState p sym ext r f a) (LCS.GlobalVar ToConcretizeType)
+stateToConcretize = LCSE.stateContext . LCSE.cruciblePersonality . toConcretize
+
+-- | Add a value to the 'ToConcretize' in the 'C.SimState'.
+addToConcretize ::
+  forall p sym ext rtp args ret ty.
+  LCB.IsSymInterface sym =>
+  HasToConcretize p =>
+  -- | Name to be displayed when pretty-printing
+  Text ->
+  LCS.RegEntry sym ty ->
+  LCS.OverrideSim p sym ext rtp args ret ()
+addToConcretize name0 ent = do
+  concVar <- State.gets (Lens.view stateToConcretize)
+  LCS.ovrWithBackend $ \bak -> do
+    let sym = LCB.backendGetSym bak
+    name <- liftIO (WI.stringLit sym (WI.UnicodeLiteral name0))
+    let LCS.RegEntry ty val = ent
+    let anyVal = LCS.AnyValue ty val
+    LCS.modifyGlobal concVar $ \toConc -> do
+      let struct = Ctx.Empty Ctx.:> LCS.RV anyVal Ctx.:> LCS.RV name
+      toConc' <- liftIO (LCSS.consSymSequence sym struct toConc)
+      pure ((), toConc')

--- a/grease/src/Grease/FunctionOverride/SExp.hs
+++ b/grease/src/Grease/FunctionOverride/SExp.hs
@@ -1,0 +1,94 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+
+module Grease.FunctionOverride.SExp
+  ( tryBindTypedOverride
+  , freshBytesOverride
+  ) where
+
+import Control.Monad qualified as Monad
+import Control.Monad.IO.Class (liftIO)
+import Data.BitVector.Sized qualified as BV
+import Data.Parameterized.Context qualified as Ctx
+import Data.Parameterized.NatRepr qualified as NatRepr
+import Data.Text (Text)
+import Data.Text qualified as Text
+import Data.Type.Ord (type (<=))
+import Data.Vector qualified as Vec
+import Lang.Crucible.Backend qualified as LCB
+import Lang.Crucible.FunctionHandle qualified as LCF
+import Lang.Crucible.Simulator qualified as LCS
+import Lang.Crucible.Types qualified as LCT
+import What4.Interface qualified as WI
+import Data.Type.Equality ((:~:)(Refl), testEquality)
+
+-- | The return value indicates whether the override was bound.
+tryBindTypedOverride ::
+  LCF.FnHandle args ret ->
+  LCS.TypedOverride p sym ext args' ret' ->
+  LCS.OverrideSim p sym ext rtp args'' ret'' Bool
+tryBindTypedOverride hdl ov =
+  case testEquality (LCF.handleArgTypes hdl) (LCS.typedOverrideArgs ov) of
+    Nothing -> pure False
+    Just Refl ->
+      case testEquality (LCF.handleReturnType hdl) (LCS.typedOverrideRet ov) of
+        Nothing -> pure False
+        Just Refl -> do
+          LCS.bindTypedOverride hdl ov
+          pure True
+
+-- | Override for @fresh-bytes@.
+--
+-- The name must be concrete. If a symbolic name is passed this function will
+-- generate an assertion failure.
+--
+-- The number of bytes must be concrete. If a symbolic number is passed this
+-- function will generate an assertion failure.
+freshBytesOverride ::
+  LCB.IsSymInterface sym =>
+  (1 <= w) =>
+  NatRepr.NatRepr w ->
+  LCS.TypedOverride p sym ext (Ctx.EmptyCtx Ctx.::> LCT.StringType WI.Unicode Ctx.::> LCT.BVType w) (LCT.VectorType (LCT.BVType 8 ))
+freshBytesOverride w =
+  WI.withKnownNat w $
+    LCS.typedOverride (Ctx.uncurryAssignment freshBytes)
+
+-- | Implementation of @fresh-bytes@ override.
+--
+-- The name must be concrete. If a symbolic name is passed this function will
+-- generate an assertion failure.
+--
+-- The number of bytes must be concrete. If a symbolic number is passed this
+-- function will generate an assertion failure.
+freshBytes ::
+  LCB.IsSymInterface sym =>
+  (1 <= w) =>
+  LCS.RegValue' sym (LCT.StringType WI.Unicode) ->
+  LCS.RegValue' sym (LCT.BVType w) ->
+  LCS.OverrideSim p sym ext r args ret (LCS.RegValue sym (LCT.VectorType (LCT.BVType 8)))
+freshBytes name0 bv0 =
+  case WI.asString (LCS.unRV name0) of
+    Nothing ->
+      LCS.overrideError $
+        LCS.AssertFailureSimError "Call to @fresh-bytes with symbolic name" ""
+    Just (WI.UnicodeLiteral name) ->
+      case WI.asBV (LCS.unRV bv0) of
+        Nothing ->
+          LCS.overrideError $
+            LCS.AssertFailureSimError "Call to @fresh-bytes with symbolic length" ""
+        Just bv -> doFreshBytes name (BV.asUnsigned bv)
+
+doFreshBytes ::
+  LCB.IsSymInterface sym =>
+  Text ->
+  Integer ->
+  LCS.OverrideSim p sym ext r args ret (LCS.RegValue sym (LCT.VectorType (LCT.BVType 8)))
+doFreshBytes name len =
+  LCS.ovrWithBackend $ \bak -> do
+    let sym = LCB.backendGetSym bak
+    fmap Vec.fromList $
+      liftIO $
+        Monad.forM [0..len] $ \i -> do
+          let nm = WI.safeSymbol (Text.unpack name ++ "_" ++ show i)
+          WI.freshConstant sym nm (WI.BaseBVRepr (NatRepr.knownNat @8))

--- a/grease/src/Grease/FunctionOverride/SExp.hs
+++ b/grease/src/Grease/FunctionOverride/SExp.hs
@@ -97,7 +97,7 @@ doFreshBytes name len =
     v <-
       fmap Vec.fromList $
         liftIO $
-          Monad.forM [0..len] $ \i -> do
+          Monad.forM [0..len - 1] $ \i -> do
             let nm = WI.safeSymbol (Text.unpack name ++ "_" ++ show i)
             WI.freshConstant sym nm (WI.BaseBVRepr (NatRepr.knownNat @8))
 

--- a/grease/src/Grease/FunctionOverride/SExp.hs
+++ b/grease/src/Grease/FunctionOverride/SExp.hs
@@ -48,7 +48,7 @@ tryBindTypedOverride hdl ov =
 -- function will generate an assertion failure.
 freshBytesOverride ::
   ( 1 <= w
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   NatRepr.NatRepr w ->
@@ -66,7 +66,7 @@ freshBytesOverride w =
 -- function will generate an assertion failure.
 freshBytes ::
   ( 1 <= w
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   LCS.RegValue' sym (LCT.StringType WI.Unicode) ->
@@ -85,7 +85,7 @@ freshBytes name0 bv0 =
         Just bv -> doFreshBytes name (BV.asUnsigned bv)
 
 doFreshBytes ::
-  ( Conc.HasToConcretize p sym
+  ( Conc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   Text ->

--- a/grease/src/Grease/FunctionOverride/SExp.hs
+++ b/grease/src/Grease/FunctionOverride/SExp.hs
@@ -17,7 +17,7 @@ import Data.Text qualified as Text
 import Data.Type.Equality ((:~:)(Refl), testEquality)
 import Data.Type.Ord (type (<=))
 import Data.Vector qualified as Vec
-import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Lang.Crucible.Backend qualified as LCB
 import Lang.Crucible.FunctionHandle qualified as LCF
 import Lang.Crucible.Simulator qualified as LCS
@@ -48,7 +48,7 @@ tryBindTypedOverride hdl ov =
 -- function will generate an assertion failure.
 freshBytesOverride ::
   ( 1 <= w
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   NatRepr.NatRepr w ->
@@ -66,7 +66,7 @@ freshBytesOverride w =
 -- function will generate an assertion failure.
 freshBytes ::
   ( 1 <= w
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   LCS.RegValue' sym (LCT.StringType WI.Unicode) ->
@@ -85,7 +85,7 @@ freshBytes name0 bv0 =
         Just bv -> doFreshBytes name (BV.asUnsigned bv)
 
 doFreshBytes ::
-  ( Conc.HasToConcretize p
+  ( ToConc.HasToConcretize p
   , LCB.IsSymInterface sym
   ) =>
   Text ->
@@ -103,6 +103,6 @@ doFreshBytes name len =
 
     let ty = LCT.VectorRepr (LCT.BVRepr (NatRepr.knownNat @8))
     let entry = LCS.RegEntry ty v
-    Conc.addToConcretize name entry
+    ToConc.addToConcretize name entry
 
     pure v

--- a/grease/src/Grease/LLVM.hs
+++ b/grease/src/Grease/LLVM.hs
@@ -49,7 +49,7 @@ newtype SetupHook sym
       , ArchWidth arch ~ 64
       , Mem.HasPtrWidth (ArchWidth arch)
       , Mem.HasLLVMAnn sym
-      , HasToConcretize p sym
+      , HasToConcretize p
       , ?lc :: TCtx.TypeContext
       , ?memOpts :: Mem.MemOptions
       , ?intrinsicsOpts :: CLLVM.IntrinsicsOptions
@@ -70,7 +70,7 @@ initState ::
   , ArchWidth arch ~ 64
   , Mem.HasPtrWidth (ArchWidth arch)
   , Mem.HasLLVMAnn sym
-  , HasToConcretize p sym
+  , HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   bak ->

--- a/grease/src/Grease/LLVM.hs
+++ b/grease/src/Grease/LLVM.hs
@@ -17,7 +17,7 @@ import Control.Lens ((^.))
 import Control.Monad.IO.Class (MonadIO(..))
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Map qualified as MapF
-import Grease.Concretize (HasToConcretize)
+import Grease.Concretize.ToConcretize (HasToConcretize)
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.LLVM.SimulatorHooks (greaseLlvmExtImpl)
 import Grease.Options (ErrorSymbolicFunCalls)

--- a/grease/src/Grease/LLVM/Overrides.hs
+++ b/grease/src/Grease/LLVM/Overrides.hs
@@ -199,7 +199,7 @@ registerLLVMOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -292,7 +292,7 @@ registerLLVMSexpOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -325,7 +325,7 @@ registerLLVMModuleOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -352,7 +352,7 @@ registerLLVMSexpProgForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   GreaseLogAction ->
@@ -374,7 +374,7 @@ registerLLVMOvForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->
@@ -394,7 +394,7 @@ registerLLVMForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->

--- a/grease/src/Grease/LLVM/Overrides.hs
+++ b/grease/src/Grease/LLVM/Overrides.hs
@@ -27,7 +27,7 @@ import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
-import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic (GreaseLogAction, Diagnostic(LLVMOverridesDiagnostic))
 import Grease.FunctionOverride (basicLLVMOverrides)
 import Grease.FunctionOverride.SExp (freshBytesOverride, tryBindTypedOverride)
@@ -199,7 +199,7 @@ registerLLVMOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -292,7 +292,7 @@ registerLLVMSexpOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -325,7 +325,7 @@ registerLLVMModuleOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -352,7 +352,7 @@ registerLLVMSexpProgForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   GreaseLogAction ->
@@ -374,7 +374,7 @@ registerLLVMOvForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->
@@ -394,7 +394,7 @@ registerLLVMForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->

--- a/grease/src/Grease/LLVM/Overrides.hs
+++ b/grease/src/Grease/LLVM/Overrides.hs
@@ -27,6 +27,7 @@ import Data.List qualified as List
 import Data.Map qualified as Map
 import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
+import Grease.Concretize qualified as Conc
 import Grease.Diagnostic (GreaseLogAction, Diagnostic(LLVMOverridesDiagnostic))
 import Grease.FunctionOverride (basicLLVMOverrides)
 import Grease.FunctionOverride.SExp (freshBytesOverride, tryBindTypedOverride)
@@ -198,6 +199,7 @@ registerLLVMOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
+  , Conc.HasToConcretize p sym
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -290,6 +292,7 @@ registerLLVMSexpOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
+  , Conc.HasToConcretize p sym
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -322,6 +325,7 @@ registerLLVMModuleOverrides ::
   ( C.IsSymBackend sym bak
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
+  , Conc.HasToConcretize p sym
   , ?lc :: TypeContext
   , ?memOpts :: Mem.MemOptions
   ) =>
@@ -348,6 +352,7 @@ registerLLVMSexpProgForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth 64
+  , Conc.HasToConcretize p sym
   , ?memOpts :: Mem.MemOptions
   ) =>
   GreaseLogAction ->
@@ -369,6 +374,7 @@ registerLLVMOvForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
+  , Conc.HasToConcretize p sym
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->
@@ -388,6 +394,7 @@ registerLLVMForwardDeclarations ::
   ( C.IsSymInterface sym
   , Mem.HasPtrWidth w
   , Mem.HasLLVMAnn sym
+  , Conc.HasToConcretize p sym
   , ?memOpts :: Mem.MemOptions
   ) =>
   C.GlobalVar Mem.Mem ->

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -48,6 +48,7 @@ import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
 import Data.Type.Equality ((:~:)(Refl))
 import Data.Word (Word8, Word64)
+import Grease.Concretize (HasToConcretize)
 import Grease.Diagnostic
 import Grease.Macaw.Arch
 import Grease.Macaw.FunctionOverride
@@ -93,6 +94,7 @@ newtype SetupHook sym arch
       , W4.OnlineSolver solver
       , Mem.HasLLVMAnn sym
       , HasGreaseSimulatorState p sym arch
+      , HasToConcretize p sym
       ) =>
       bak ->
       C.GlobalVar Mem.Mem ->
@@ -502,6 +504,7 @@ initState ::
   , Mem.HasLLVMAnn sym
   , ?memOpts :: Mem.MemOptions
   , HasGreaseSimulatorState p sym arch
+  , HasToConcretize p sym
   ) =>
   bak ->
   GreaseLogAction ->
@@ -514,7 +517,8 @@ initState ::
   ArchContext arch ->
   Symbolic.MemPtrTable sym (MC.ArchAddrWidth arch) ->
   SetupHook sym arch ->
-  -- | The initial personality state.
+  -- | The initial personality, see
+  -- 'Lang.Crucible.Simulator.ExecutionTree.cruciblePersonality'
   p ->
   -- | The initial register state.
   ArchRegs sym arch ->

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -48,7 +48,7 @@ import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
 import Data.Type.Equality ((:~:)(Refl))
 import Data.Word (Word8, Word64)
-import Grease.Concretize (HasToConcretize)
+import Grease.Concretize.ToConcretize (HasToConcretize)
 import Grease.Diagnostic
 import Grease.Macaw.Arch
 import Grease.Macaw.FunctionOverride

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -94,7 +94,7 @@ newtype SetupHook sym arch
       , W4.OnlineSolver solver
       , Mem.HasLLVMAnn sym
       , HasGreaseSimulatorState p sym arch
-      , HasToConcretize p sym
+      , HasToConcretize p
       ) =>
       bak ->
       C.GlobalVar Mem.Mem ->
@@ -504,7 +504,7 @@ initState ::
   , Mem.HasLLVMAnn sym
   , ?memOpts :: Mem.MemOptions
   , HasGreaseSimulatorState p sym arch
-  , HasToConcretize p sym
+  , HasToConcretize p
   ) =>
   bak ->
   GreaseLogAction ->

--- a/grease/src/Grease/Macaw/FunctionOverride.hs
+++ b/grease/src/Grease/Macaw/FunctionOverride.hs
@@ -32,7 +32,7 @@ import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.TraversableFC (fmapFC)
 import Data.Proxy (Proxy(..))
 import Data.Sequence qualified as Seq
-import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.FunctionOverride.SExp (tryBindTypedOverride, freshBytesOverride)
 import Grease.Macaw.Arch
@@ -237,7 +237,7 @@ registerMacawSexpProgForwardDeclarations ::
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth (MC.ArchAddrWidth arch)
   , Symbolic.SymArchConstraints arch
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   bak ->
@@ -262,7 +262,7 @@ registerMacawOvForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)
@@ -283,7 +283,7 @@ registerMacawForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)

--- a/grease/src/Grease/Macaw/FunctionOverride.hs
+++ b/grease/src/Grease/Macaw/FunctionOverride.hs
@@ -237,7 +237,7 @@ registerMacawSexpProgForwardDeclarations ::
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth (MC.ArchAddrWidth arch)
   , Symbolic.SymArchConstraints arch
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   ) =>
   bak ->
@@ -262,7 +262,7 @@ registerMacawOvForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)
@@ -283,7 +283,7 @@ registerMacawForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
-  , Conc.HasToConcretize p sym
+  , Conc.HasToConcretize p
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)

--- a/grease/src/Grease/Macaw/FunctionOverride.hs
+++ b/grease/src/Grease/Macaw/FunctionOverride.hs
@@ -32,6 +32,7 @@ import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.TraversableFC (fmapFC)
 import Data.Proxy (Proxy(..))
 import Data.Sequence qualified as Seq
+import Grease.Concretize qualified as Conc
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.FunctionOverride.SExp (tryBindTypedOverride, freshBytesOverride)
 import Grease.Macaw.Arch
@@ -236,6 +237,7 @@ registerMacawSexpProgForwardDeclarations ::
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth (MC.ArchAddrWidth arch)
   , Symbolic.SymArchConstraints arch
+  , Conc.HasToConcretize p sym
   , ?memOpts :: Mem.MemOptions
   ) =>
   bak ->
@@ -260,6 +262,7 @@ registerMacawOvForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
+  , Conc.HasToConcretize p sym
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)
@@ -280,6 +283,7 @@ registerMacawForwardDeclarations ::
   , bak ~ C.OnlineBackend solver scope st fs
   , W4.OnlineSolver solver
   , Mem.HasPtrWidth w
+  , Conc.HasToConcretize p sym
   ) =>
   bak ->
   Map.Map W4.FunctionName (MacawFunctionOverride p sym arch)

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -31,6 +31,7 @@ import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Map qualified as MapF
+import Grease.Concretize qualified as Conc
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.Simulator qualified as C
 import Stubs.Syscall qualified as Stubs
@@ -42,6 +43,7 @@ data GreaseSimulatorState sym arch = GreaseSimulatorState
     -- function is discovered (see @Note [Incremental code discovery]@), it will
     -- be added to this map so that it can be looked up in future invocations of
     -- that function.
+  , _toConcretize :: Conc.ToConcretize sym
   , _syscallHandles :: MapF.MapF Stubs.SyscallNumRepr Stubs.SyscallFnHandle
     -- ^ A map of syscall numbers (that have been invoked thus far during
     -- simulation) to their handles. Any time a new syscall is simulated, it
@@ -74,6 +76,7 @@ data GreaseSimulatorState sym arch = GreaseSimulatorState
 emptyGreaseSimulatorState :: GreaseSimulatorState sym arch
 emptyGreaseSimulatorState = GreaseSimulatorState
   { _discoveredFnHandles = Map.empty
+  , _toConcretize = Conc.ToConcretize []
   , _syscallHandles = MapF.empty
   , _macawLazySimulatorState = Symbolic.emptyMacawLazySimulatorState
   }
@@ -110,6 +113,9 @@ type MacawOverride p sym arch =
 -----
 
 makeLenses ''GreaseSimulatorState
+
+instance Conc.HasToConcretize (GreaseSimulatorState sym arch) sym where
+  toConcretize = toConcretize
 
 instance (MC.ArchAddrWidth arch ~ w) =>
          Symbolic.HasMacawLazySimulatorState

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -31,7 +31,7 @@ import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Map qualified as MapF
-import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.Simulator qualified as C
 import Stubs.Syscall qualified as Stubs
@@ -43,7 +43,7 @@ data GreaseSimulatorState sym arch = GreaseSimulatorState
     -- function is discovered (see @Note [Incremental code discovery]@), it will
     -- be added to this map so that it can be looked up in future invocations of
     -- that function.
-  , _toConcretize :: C.GlobalVar Conc.ToConcretizeType
+  , _toConcretize :: C.GlobalVar ToConc.ToConcretizeType
     -- ^ Values created during runtime to be passed to the concretization
     -- functionality and generally displayed to the user.
   , _syscallHandles :: MapF.MapF Stubs.SyscallNumRepr Stubs.SyscallFnHandle
@@ -76,7 +76,7 @@ data GreaseSimulatorState sym arch = GreaseSimulatorState
 
 -- | An initial value for 'GreaseSimulatorState'.
 emptyGreaseSimulatorState ::
-  C.GlobalVar Conc.ToConcretizeType ->
+  C.GlobalVar ToConc.ToConcretizeType ->
   GreaseSimulatorState sym arch
 emptyGreaseSimulatorState toConcVar = GreaseSimulatorState
   { _discoveredFnHandles = Map.empty
@@ -118,7 +118,7 @@ type MacawOverride p sym arch =
 
 makeLenses ''GreaseSimulatorState
 
-instance Conc.HasToConcretize (GreaseSimulatorState sym arch) where
+instance ToConc.HasToConcretize (GreaseSimulatorState sym arch) where
   toConcretize = toConcretize
 
 instance (MC.ArchAddrWidth arch ~ w) =>

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -25,6 +25,7 @@ module Grease.Macaw.SimulatorState
   ) where
 
 import Control.Lens (Lens')
+import Control.Lens qualified as Lens
 import Control.Lens.TH (makeLenses)
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Symbolic qualified as Symbolic
@@ -119,7 +120,7 @@ type MacawOverride p sym arch =
 makeLenses ''GreaseSimulatorState
 
 instance ToConc.HasToConcretize (GreaseSimulatorState sym arch) where
-  toConcretize = toConcretize
+  toConcretize = Lens.view toConcretize
 
 instance (MC.ArchAddrWidth arch ~ w) =>
          Symbolic.HasMacawLazySimulatorState

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -271,7 +271,7 @@ consumer bak anns la heuristics argNames argShapes bbMap initState =
         doLog la (Diag.SolverGoalPassed (C.simErrorLoc simErr))
         pure ProveSuccess
       C.Disproved groundEvalFn _ -> do
-        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState
+        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState []
         doLog la $ Diag.SolverGoalFailed sym lp minfo
         let
           runHeuristics ::

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -106,6 +106,7 @@ import Data.Type.Equality (type (~))
 import Grease.Bug qualified as Bug
 import Grease.Concretize (ConcretizedData)
 import Grease.Concretize qualified as Conc
+import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic
 import Grease.Heuristic
 import Grease.Options (LoopBound(..), Milliseconds(..))
@@ -237,7 +238,7 @@ consumer ::
   ) =>
   bak ->
   Anns.Annotations sym ext argTys ->
-  C.RegValue sym Conc.ToConcretizeType ->
+  C.RegValue sym ToConc.ToConcretizeType ->
   GreaseLogAction ->
   [RefineHeuristic sym bak ext argTys] ->
   -- | Argument names
@@ -338,7 +339,7 @@ proveAndRefine ::
   bak ->
   Solver ->
   Anns.Annotations sym ext argTys ->
-  C.RegValue sym Conc.ToConcretizeType ->
+  C.RegValue sym ToConc.ToConcretizeType ->
   GreaseLogAction ->
   [RefineHeuristic sym bak ext argTys] ->
   -- | Argument names
@@ -373,7 +374,7 @@ execAndRefine ::
   , 16 C.<= w
   , Mem.HasLLVMAnn sym
   , Mem.HasPtrWidth w
-  , Conc.HasToConcretize p
+  , ToConc.HasToConcretize p
   , ?memOpts :: Mem.MemOptions
   , ExtShape ext ~ PtrShape ext w
   ) =>
@@ -396,7 +397,7 @@ execAndRefine bak solver _fm la anns heuristics argNames argShapes initState bbM
   (result, goals) <- liftIO (execCfg bak (LoopBound bound) execFeats initialState)
   doLog la (Diag.ExecutionResult result)
   bbMap <- liftIO (readIORef bbMapRef)
-  toConc <- liftIO (Conc.readToConcretize result)
+  toConc <- liftIO (ToConc.readToConcretize result)
   liftIO (proveAndRefine bak solver anns toConc la heuristics argNames argShapes initState bbMap goals)
 
 data RefinementSummary sym ext tys

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -271,7 +271,7 @@ consumer bak anns la heuristics argNames argShapes bbMap initState =
         doLog la (Diag.SolverGoalPassed (C.simErrorLoc simErr))
         pure ProveSuccess
       C.Disproved groundEvalFn _ -> do
-        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState []
+        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState (Conc.ToConcretize [])
         doLog la $ Diag.SolverGoalFailed sym lp minfo
         let
           runHeuristics ::

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -271,7 +271,8 @@ consumer bak anns la heuristics argNames argShapes bbMap initState =
         doLog la (Diag.SolverGoalPassed (C.simErrorLoc simErr))
         pure ProveSuccess
       C.Disproved groundEvalFn _ -> do
-        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState (Conc.ToConcretize [])
+        let toConc = Conc.ToConcretize []  -- TODO: get from personality
+        cData <- Conc.makeConcretizedData bak groundEvalFn minfo initState toConc
         doLog la $ Diag.SolverGoalFailed sym lp minfo
         let
           runHeuristics ::

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -126,10 +126,7 @@ import Lang.Crucible.LLVM.MemModel.CallStack qualified as Mem
 import Lang.Crucible.Simulator qualified as C
 import Lang.Crucible.Simulator.BoundedExec qualified as C
 import Lang.Crucible.Simulator.BoundedRecursion qualified as C
-import Lang.Crucible.Simulator.ExecutionTree qualified as C
-import Lang.Crucible.Simulator.GlobalState qualified as C
 import Lang.Crucible.Simulator.SimError qualified as C
-import Lang.Crucible.Simulator.SymSequence qualified as C
 import Lang.Crucible.Utils.Seconds qualified as C
 import Lang.Crucible.Utils.Timeout qualified as C
 import Lumberjack qualified as LJ
@@ -399,10 +396,7 @@ execAndRefine bak solver _fm la anns heuristics argNames argShapes initState bbM
   (result, goals) <- liftIO (execCfg bak (LoopBound bound) execFeats initialState)
   doLog la (Diag.ExecutionResult result)
   bbMap <- liftIO (readIORef bbMapRef)
-  let simCtx = C.execResultContext result
-  let toConcVar = simCtx ^. C.cruciblePersonality . Conc.toConcretize
-  globs <- liftIO (C.execResultGlobals result)
-  let toConc = Maybe.fromMaybe C.SymSequenceNil (C.lookupGlobal toConcVar globs)
+  toConc <- liftIO (Conc.readToConcretize result)
   liftIO (proveAndRefine bak solver anns toConc la heuristics argNames argShapes initState bbMap goals)
 
 data RefinementSummary sym ext tys


### PR DESCRIPTION
Fixes #201.

- [x] Initial `fresh-bytes` override
- [x] Thread fresh values through to concretization