### PR TITLE
Disable `-Werror=prepositive-qualified-module` in Cabal files

### DIFF
--- a/grease-aarch32/grease-aarch32.cabal
+++ b/grease-aarch32/grease-aarch32.cabal
@@ -27,7 +27,7 @@ common shared
   -- See doc/style.md
   ghc-options:
     -Werror=missing-export-lists
-    -Werror=prepositive-qualified-module
+    -Wprepositive-qualified-module
 
   -- Specifying -Wall and -Werror can cause the project to fail to build on
   -- newer versions of GHC simply due to new warnings being added to -Wall. To

--- a/grease-aarch32/grease-aarch32.cabal
+++ b/grease-aarch32/grease-aarch32.cabal
@@ -25,6 +25,8 @@ common shared
   build-depends: base >= 4.17 && < 4.20
 
   -- See doc/style.md
+  --
+  -- We can't use `-Werror=prepositive...` because of ndmitchell/ghcid#358.
   ghc-options:
     -Werror=missing-export-lists
     -Wprepositive-qualified-module

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -27,6 +27,8 @@ common shared
   build-depends: base >= 4.17 && < 4.20
 
   -- See doc/style.md
+  --
+  -- We can't use `-Werror=prepositive...` because of ndmitchell/ghcid#358.
   ghc-options:
     -Werror=missing-export-lists
     -Wprepositive-qualified-module

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -29,7 +29,7 @@ common shared
   -- See doc/style.md
   ghc-options:
     -Werror=missing-export-lists
-    -Werror=prepositive-qualified-module
+    -Wprepositive-qualified-module
 
   -- Specifying -Wall and -Werror can cause the project to fail to build on
   -- newer versions of GHC simply due to new warnings being added to -Wall. To

--- a/grease-ppc/grease-ppc.cabal
+++ b/grease-ppc/grease-ppc.cabal
@@ -27,7 +27,7 @@ common shared
   -- See doc/style.md
   ghc-options:
     -Werror=missing-export-lists
-    -Werror=prepositive-qualified-module
+    -Wprepositive-qualified-module
 
   -- Specifying -Wall and -Werror can cause the project to fail to build on
   -- newer versions of GHC simply due to new warnings being added to -Wall. To

--- a/grease-ppc/grease-ppc.cabal
+++ b/grease-ppc/grease-ppc.cabal
@@ -25,6 +25,8 @@ common shared
   build-depends: base >= 4.17 && < 4.20
 
   -- See doc/style.md
+  --
+  -- We can't use `-Werror=prepositive...` because of ndmitchell/ghcid#358.
   ghc-options:
     -Werror=missing-export-lists
     -Wprepositive-qualified-module

--- a/grease-x86/grease-x86.cabal
+++ b/grease-x86/grease-x86.cabal
@@ -27,7 +27,7 @@ common shared
   -- See doc/style.md
   ghc-options:
     -Werror=missing-export-lists
-    -Werror=prepositive-qualified-module
+    -Wprepositive-qualified-module
 
   -- Specifying -Wall and -Werror can cause the project to fail to build on
   -- newer versions of GHC simply due to new warnings being added to -Wall. To

--- a/grease-x86/grease-x86.cabal
+++ b/grease-x86/grease-x86.cabal
@@ -25,6 +25,8 @@ common shared
   build-depends: base >= 4.17 && < 4.20
 
   -- See doc/style.md
+  --
+  -- We can't use `-Werror=prepositive...` because of ndmitchell/ghcid#358.
   ghc-options:
     -Werror=missing-export-lists
     -Wprepositive-qualified-module

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -27,6 +27,8 @@ common shared
   build-depends: base >= 4.17 && < 4.20
 
   -- See doc/style.md
+  --
+  -- We can't use `-Werror=prepositive...` because of ndmitchell/ghcid#358.
   ghc-options:
     -Werror=missing-export-lists
     -Wprepositive-qualified-module

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -29,7 +29,7 @@ common shared
   -- See doc/style.md
   ghc-options:
     -Werror=missing-export-lists
-    -Werror=prepositive-qualified-module
+    -Wprepositive-qualified-module
 
   -- Specifying -Wall and -Werror can cause the project to fail to build on
   -- newer versions of GHC simply due to new warnings being added to -Wall. To


### PR DESCRIPTION
Otherwise it messes with `ghcid`. Fixes #213.