### PR TITLE
Also register `fresh-bytes` when executing binaries 

### DIFF
--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -424,6 +424,8 @@ memConfigWithHandles ::
   , ?memOpts :: Mem.MemOptions
   , Mem.HasLLVMAnn sym
   , HasGreaseSimulatorState p sym arch
+  , Mem.HasPtrWidth (MC.ArchAddrWidth arch)
+  , HasToConcretize p
   ) =>
   bak ->
   GreaseLogAction ->

--- a/grease/src/Grease/Macaw/FunctionOverride.hs
+++ b/grease/src/Grease/Macaw/FunctionOverride.hs
@@ -301,8 +301,8 @@ registerMacawForwardDeclarations bak funOvs cannotResolve fwdDecs =
   Foldable.forM_ (Map.toList fwdDecs) $ \(decName, C.SomeHandle hdl) ->
     registerMacawForwardDeclaration bak funOvs cannotResolve decName hdl
 
--- | Redirect handles for forward declarations in an S-expression file to
--- actually call the corresponding Macaw overrides. If a forward declaration
+-- | Redirect a handle for a forward declaration in an S-expression file to
+-- actually call the corresponding Macaw override. If the forward declaration
 -- name cannot be resolved to an override, then perform the supplied action.
 registerMacawForwardDeclaration ::
   ( C.IsSymBackend sym bak
@@ -330,7 +330,7 @@ registerMacawForwardDeclaration bak funOvs cannotResolve decName hdl =
     Nothing -> cannotResolve decName hdl
     Just ov -> C.bindFnHandle hdl (C.UseOverride ov)
 
--- | Lookup an override for a function handle from a forward declaration
+-- | Lookup an override for a function handle from a forward declaration.
 lookupMacawForwardDeclarationOverride ::
   forall p sym bak arch scope st fs solver args ret.
   ( C.IsSymBackend sym bak

--- a/grease/src/Grease/Macaw/FunctionOverride.hs
+++ b/grease/src/Grease/Macaw/FunctionOverride.hs
@@ -321,9 +321,9 @@ registerMacawForwardDeclaration ::
     C.OverrideSim p sym (Symbolic.MacawExt arch) rtp a r ())
     {- ^ What to do when a forward declaration cannot be resolved. -} ->
   W4.FunctionName
-    {-^ Name of the forward declaration -} ->
+    {- ^ Name of the forward declaration -} ->
   C.FnHandle args' ret'
-    {-^ Handle to bind -} ->
+    {- ^ Handle to bind -} ->
   C.OverrideSim p sym (Symbolic.MacawExt arch) rtp a r ()
 registerMacawForwardDeclaration bak funOvs cannotResolve decName hdl =
   case lookupMacawForwardDeclarationOverride bak funOvs decName hdl of

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -575,9 +575,13 @@ useMacawFunctionOverride ::
   MacawFunctionOverride p sym arch ->
   C.SimState p sym (Symbolic.MacawExt arch) r f a ->
   IO (MacawFnHandle arch, C.SimState p sym (Symbolic.MacawExt arch) r f a)
-useMacawFunctionOverride bak la halloc arch allOvs
-      (MacawFunctionOverride publicOvHdl publicOv (Stubs.SomeFunctionOverride fnOv)) st0 =
- do let C.FnBindings fnHdlMap0 = st0 ^. C.stateContext . C.functionBindings
+useMacawFunctionOverride bak la halloc arch allOvs mOv st0 =
+ do MacawFunctionOverride
+      { mfoPublicFnHandle = publicOvHdl
+      , mfoPublicOverride = publicOv
+      , mfoSomeFunctionOverride = Stubs.SomeFunctionOverride fnOv
+      } <- pure mOv
+    let C.FnBindings fnHdlMap0 = st0 ^. C.stateContext . C.functionBindings
         fnOvName = Stubs.functionName fnOv
     doLog la $ Diag.FunctionOverride fnOvName
     fnHdlMap1 <- extendHandleMap bak allOvs fnOv fnHdlMap0


### PR DESCRIPTION
...by sharing a bit more code between the override-registration code for S-expression programs (which is eager) and that for binaries (which is lazy and recursive).