### PR TITLE
`tests/sanity/pass/startup-override`: Only pass `symbol-startup-override` entrypoints

### DIFF
--- a/grease-cli/tests/sanity/pass/startup-override/test.c
+++ b/grease-cli/tests/sanity/pass/startup-override/test.c
@@ -1,6 +1,5 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
-// all: flags {"--symbol", "test"}
 // arm: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.armv7l.cbl"}
 // ppc32: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.ppc32.cbl", "--plt-stub", "0x10000220:memset"}
 // x64: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.x86_64.cbl"}


### PR DESCRIPTION
Previously, we also passed an additional `--symbol test` entrypoint, but this would be unfortunately slow due to the lack of a startup override for this particular test. We now only pass `--symbol-startup-override` entrypoints to ensure that this test completes in a reasonable amount of time.

Fixes #232.