### PR TITLE
`Grease.Shape.Parse`: Export `ParseError`

### DIFF
--- a/grease/src/Grease/Shape/Parse.hs
+++ b/grease/src/Grease/Shape/Parse.hs
@@ -20,6 +20,7 @@ See @doc/shape-dsl.md@ for a description of the syntax.
 module Grease.Shape.Parse
   ( parseShapes
   , ParsedShapes(..)
+  , ParseError(..)
   , TypeMismatch(..)
   , replaceShapes
   ) where


### PR DESCRIPTION
This is used in the return type of `parseShapes` (part of the public API), and therefore `ParseError` ought to be part of the public API too. I'd like to use `ParseError` elsewhere in a downstream application.