### PR TITLE
tests: Embed `CFLAGS` in comments in C sources for LLVM bc tests

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -67,7 +67,9 @@ organized into different subdirectories:
    the file extension `*.llvm.cbl`.
 
 2. `llvm-bc/`: LLVM bitcode files (via `grease`'s LLVM frontend). Each of these
-   test cases has the file extension `*.bc`.
+   test cases has the file extension `*.bc`. Files in this directory may specify
+   additional flags to be passed to the C compiler using the special comment
+   `// CFLAGS: `, e.g., `// CFLAGS: -g`.
 
 3. `arm`: AArch32 machine-code CFGs (via `macaw-aarch32-syntax`). Each of these
    test cases has the file extension `*.armv7l.cbl`.

--- a/grease-cli/tests/Makefile
+++ b/grease-cli/tests/Makefile
@@ -119,10 +119,11 @@ SOS = $(SHARED_LIBRARY_ARM_SOS) $(SHARED_LIBRARY_X64_SOS) $(SHARED_LIBRARY_PPC32
 
 BC_DIRS = $(shell find llvm-bc/ -mindepth 1 -maxdepth 1 -type d)
 BCS = $(addsuffix /test.bc,$(BC_DIRS))
+STANDALONE_BCS = $(patsubst %.c, %.bc, $(wildcard llvm-bc/*.c))
 
 .PHONY: all fmt clean
 
-all: $(EXES) $(SOS) $(BCS)
+all: $(EXES) $(SOS) $(BCS) $(STANDALONE_BCS)
 
 fmt:
 	clang-format -i $(DIRS:=/test.c)
@@ -200,7 +201,10 @@ $(STANDALONE_SHARED_LIBRARY_PPC32_SOS): %/test.ppc32.elf: %/test.c
 	$(PPC32CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -fpic -shared $< -o $@
 
 $(BCS): %/test.bc: %/test.c
-	$(X64CC) -emit-llvm -frecord-command-line -c -o $@ $<
+	$(X64CC) $(shell ./extract-cflags.sh $<) -c -o $@ $<
+
+llvm-bc/%.bc: llvm-bc/%.c
+	$(X64CC) $(shell ./extract-cflags.sh $<) -c -o $@ $<
 
 clean:
 	rm -f $(EXES)

--- a/grease-cli/tests/extract-cflags.sh
+++ b/grease-cli/tests/extract-cflags.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+# Extract C compiler flags embedded in test files. See `doc/dev/tests.md` and
+# the Makefile.
+
+set -eu
+
+grep '^// CFLAGS: ' "${1}" | sed 's|^// CFLAGS: ||'

--- a/grease-cli/tests/llvm-bc/declare-in-override.c
+++ b/grease-cli/tests/llvm-bc/declare-in-override.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// flags {"--overrides", "tests/llvm-bc/extra/my_malloc.llvm.cbl"}
 /// go(prog)

--- a/grease-cli/tests/llvm-bc/load-handle.c
+++ b/grease-cli/tests/llvm-bc/load-handle.c
@@ -2,6 +2,8 @@
 
 // A regression test for gitlab#158.
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// flags {"--overrides", "tests/llvm-bc/extra/f.cbl"}
 /// go(prog)

--- a/grease-cli/tests/llvm-bc/malloc-free-redefined.c
+++ b/grease-cli/tests/llvm-bc/malloc-free-redefined.c
@@ -2,6 +2,8 @@
 
 // A regression test for gitlab#156.
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// go(prog)
 

--- a/grease-cli/tests/llvm-bc/memset.c
+++ b/grease-cli/tests/llvm-bc/memset.c
@@ -4,6 +4,8 @@
 // as `memset` are properly handled; and for gitlab#186, test that the
 // heuristics handle `memset` by allocating enough space.
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// go(prog)
 

--- a/grease-cli/tests/llvm-bc/multiple-defines.c
+++ b/grease-cli/tests/llvm-bc/multiple-defines.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// go(prog)
 

--- a/grease-cli/tests/llvm-bc/skip.c
+++ b/grease-cli/tests/llvm-bc/skip.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol", "test"}
 /// go(prog)
 

--- a/grease-cli/tests/llvm-bc/startup-override.c
+++ b/grease-cli/tests/llvm-bc/startup-override.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: -emit-llvm -frecord-command-line
+
 /// flags {"--symbol-startup-override", "test:tests/llvm-bc/extra/startup-override.llvm.cbl"}
 /// go(prog)
 


### PR DESCRIPTION
Fixes #256. Only does it for tests in `llvm-bc/` at the moment because that's my immediate need, but paves the way for future extensions.