### PR TITLE
Add some docs and support for ghidra script type stubs

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -32,6 +32,7 @@
 - [Development](dev/dev.md)
 - [Fancy Haskell idioms](dev/haskell-idioms.md)
 - [On-boarding](dev/on-boarding.md)
+- [Ghidra Script Development with Type Stubs](dev/ghidra-script-dev.md)
 - [Glossary](dev/glossary.md)
 - [Practices](dev/practices.md)
 - [Profiling](dev/profiling.md)

--- a/doc/dev/ghidra-script-dev.md
+++ b/doc/dev/ghidra-script-dev.md
@@ -12,3 +12,7 @@ pip install ghidra-stubs
 ```
 
 Editors that support type stubs will be able to use this virtualenv to provide partial autocomplete support.
+
+## Linting
+
+See the [linting section of the dev docs](dev.md) for discussion of how to lint this script with ruff.

--- a/doc/dev/ghidra-script-dev.md
+++ b/doc/dev/ghidra-script-dev.md
@@ -7,7 +7,7 @@ Using [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) o
 
 ```sh
 mkvirtualenv ghidradev
-workon ghidradev 
+workon ghidradev
 pip install ghidra-stubs
 ```
 

--- a/doc/dev/ghidra-script-dev.md
+++ b/doc/dev/ghidra-script-dev.md
@@ -1,0 +1,14 @@
+# Ghidra Script Development with Type Stubs
+
+Partial autocomplete can be enabled for the ghidra script (ghidra_scripts/grease.py) by installing the upstream distributed
+[python stubs](https://pypi.org/project/ghidra-stubs/).
+
+Using [virtualenvwrapper](https://virtualenvwrapper.readthedocs.io/en/latest/) one can setup the stubs by running:
+
+```sh
+mkvirtualenv ghidradev
+workon ghidradev 
+pip install ghidra-stubs
+```
+
+Editors that support type stubs will be able to use this virtualenv to provide partial autocomplete support.

--- a/ghidra_scripts/grease.py
+++ b/ghidra_scripts/grease.py
@@ -23,7 +23,8 @@
 # @copyright Galois Inc. 2024
 
 # Many names are defined by Ghidra, but Ruff doesn't know that
-# ruff: noqa: F821
+# Also allow star imports for builtin stubs
+# ruff: noqa: F821 F405 F403
 
 # This one is just too opinionated
 # ruff: noqa: E741

--- a/ghidra_scripts/grease.py
+++ b/ghidra_scripts/grease.py
@@ -38,7 +38,7 @@ import tempfile
 import typing
 
 if typing.TYPE_CHECKING:
-    from ghidra.ghidra_builtins import * # type: ignore
+    from ghidra.ghidra_builtins import *  # type: ignore
 
 
 from java.awt import Color

--- a/ghidra_scripts/grease.py
+++ b/ghidra_scripts/grease.py
@@ -34,6 +34,11 @@ import os
 import re
 import subprocess
 import tempfile
+import typing
+
+if typing.TYPE_CHECKING:
+    from ghidra.ghidra_builtins import * # type: ignore
+
 
 from java.awt import Color
 


### PR DESCRIPTION
Potentially in the future we want to move to a gradle setup with a plugin bound to a ghidra install dir. I tend to find that type of setup more maintainable for larger projects etc but for the moment this adds some docs on how to setup pyi stubs for ghidra

I am glad upstream now distributes these rather than having to generate them yourself 