### PR TITLE
cli: Add groups of command-line options

### DIFF
--- a/doc/diagrams/grease-diagrams.cabal
+++ b/doc/diagrams/grease-diagrams.cabal
@@ -100,6 +100,6 @@ executable grease-diagrams
     default-language: Haskell2010
     build-depends:
       base >= 4.17 && < 4.20,
-      diagrams ^>=1.4,
-      diagrams-lib ^>=1.4,
-      diagrams-svg ^>=1.4
+      diagrams ^>= 1.4,
+      diagrams-lib ^>= { 1.4, 1.5 },
+      diagrams-svg ^>= { 1.4, 1.5 }

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -149,7 +149,7 @@ library
     , lens ^>= 5.3
     , lumberjack ^>= 1.0
     , megaparsec ^>= 9.6
-    , optparse-applicative
+    , optparse-applicative ^>= 0.19.0.0
     , safe-exceptions ^>= 0.1.7.4
     , text ^>= { 2.0, 2.1 }
     , vector ^>= 0.13.2

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -57,14 +57,13 @@ boundedEnumMetavar _ = Opt.metavar $ varShowS ""
 
 entrypointParser :: Opt.Parser Entrypoint
 entrypointParser =
-  inGroup addressParser
-    Opt.<|> inGroup symbolParser
-    Opt.<|> inGroup coreDumpParser
-    Opt.<|> inGroup addressStartupOvParser
-    Opt.<|> inGroup symbolStartupOvParser
+  Opt.parserOptionGroup "Entrypoint options" $
+    addressParser
+      Opt.<|> symbolParser
+      Opt.<|> coreDumpParser
+      Opt.<|> addressStartupOvParser
+      Opt.<|> symbolStartupOvParser
  where
-  inGroup = Opt.parserOptionGroup "Entrypoint options"
-
   addressParser =
     entrypointNoStartupOv . EntrypointAddress
       <$> Opt.strOption

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -341,8 +341,8 @@ processSimOpts sOpts =
 
 opts :: Opt.Parser GO.Opts
 opts = do
-  optsJSON <- Opt.switch (Opt.long "json" <> Opt.help "output JSON")
   optsSimOpts <- processSimOpts <$> simOpts
+  optsJSON <- Opt.switch (Opt.long "json" <> Opt.help "output JSON")
 
   let minSeverity = Sev.severityToNat Sev.Info
   -- count the `-v`s


### PR DESCRIPTION
We have 27 options and some of them fall into recognizable groups. Let's start organizing them, especially since I'm about to add a bunch more in #228. A disadvantage is that all groups appear after all non-grouped options, but I don't really want to add a "default" group, especially since it'd be easy to forget it when adding a new option and then have a lone flag that appears before all groups.