### PR TITLE
cli: Add flags for specifying initial register values

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,3 +1,6 @@
+-- https://github.com/kquick/tasty-sugar/issues/4
+allow-newer: tasty-sugar:optparse-applicative
+
 packages:
   grease/grease.cabal
   grease-cli/grease-cli.cabal

--- a/doc/diagrams/grease-diagrams.cabal
+++ b/doc/diagrams/grease-diagrams.cabal
@@ -100,6 +100,6 @@ executable grease-diagrams
     default-language: Haskell2010
     build-depends:
       base >= 4.17 && < 4.20,
-      diagrams ^>=1.4,
-      diagrams-lib ^>=1.4,
-      diagrams-svg ^>=1.4
+      diagrams ^>= 1.4,
+      diagrams-lib ^>= { 1.4, 1.5 },
+      diagrams-svg ^>= { 1.4, 1.5 }

--- a/doc/refinement.md
+++ b/doc/refinement.md
@@ -61,6 +61,19 @@ sets the register to a pointer to the base of that allocation. It then
 initializes the allocation according to the pointee shapes (which may create
 and initialize additional allocations, recursively).
 
+There are a few ways to influence the initial shapes held in registers:
+
+- Allow GREASE to use LLVM or DWARF debug info to fill them in by passing
+  `--use-debug-info`.
+- Provide a [Shape DSL](shape-dsl.md) file to `--initial-precondition`.
+<!-- TODO(#228)
+- Specify initial register values with flags, including `--reg-int` and
+  `--reg-buf-{un,}init`.
+-->
+- Provide a [startup override](overrides.md).
+
+The later methods override the earlier ones.
+
 ## The refinement loop
 
 The refinement loop proceeds by initializing memory and registers according to

--- a/doc/refinement.md
+++ b/doc/refinement.md
@@ -66,10 +66,7 @@ There are a few ways to influence the initial shapes held in registers:
 - Allow GREASE to use LLVM or DWARF debug info to fill them in by passing
   `--use-debug-info`.
 - Provide a [Shape DSL](shape-dsl.md) file to `--initial-precondition`.
-<!-- TODO(#228)
-- Specify initial register values with flags, including `--reg-int` and
-  `--reg-buf-{un,}init`.
--->
+- Specify initial register values with flags such as `--arg-buf-unint`.
 - Provide a [startup override](overrides.md).
 
 The later methods override the earlier ones.

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -149,7 +149,7 @@ library
     , lens ^>= 5.3
     , lumberjack ^>= 1.0
     , megaparsec ^>= 9.6
-    , optparse-applicative
+    , optparse-applicative ^>= 0.19.0.0
     , safe-exceptions ^>= 0.1.7.4
     , text ^>= { 2.0, 2.1 }
     , vector ^>= 0.13.2

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -341,8 +341,8 @@ processSimOpts sOpts =
 
 opts :: Opt.Parser GO.Opts
 opts = do
-  optsJSON <- Opt.switch (Opt.long "json" <> Opt.help "output JSON")
   optsSimOpts <- processSimOpts <$> simOpts
+  optsJSON <- Opt.switch (Opt.long "json" <> Opt.help "output JSON")
 
   let minSeverity = Sev.severityToNat Sev.Info
   -- count the `-v`s

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -13,6 +13,7 @@ module Grease.Cli (
 ) where
 
 import Control.Applicative (optional, (<**>))
+import Data.Char qualified as Char
 import Data.List qualified as List
 import Data.Map.Strict (Map)
 import Data.Map.Strict qualified as Map
@@ -34,7 +35,6 @@ import Grease.Solver (Solver (..))
 import Grease.Version (verStr)
 import Options.Applicative qualified as Opt
 import Text.Megaparsec qualified as TM
-import Text.Megaparsec.Char qualified as TMP
 
 megaparsecReader :: TM.Parsec Void Text a -> Opt.ReadM a
 megaparsecReader p = Opt.eitherReader $ \rawStr ->
@@ -113,7 +113,7 @@ entrypointParser =
 
 simpleShapesParser :: Opt.Parser (Map Text SimpleShape)
 simpleShapesParser = fmap Map.fromList $ Opt.many $ do
-  let argName = Text.pack <$> TM.some TMP.alphaNumChar
+  let argName = TM.takeWhile1P Nothing (\c -> Char.isAscii c && c /= ':')
   Opt.option
     (megaparsecReader ((,) <$> argName <*> (TM.chunk ":" *> Simple.parseUninit)))
     ( Opt.long "arg-buf-uninit"

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE RecordWildCards #-}
 
 -- |
@@ -13,6 +14,8 @@ module Grease.Cli (
 
 import Control.Applicative (optional, (<**>))
 import Data.List qualified as List
+import Data.Map.Strict (Map)
+import Data.Map.Strict qualified as Map
 import Data.Proxy (Proxy (..))
 import Data.String qualified as String
 import Data.Text (Text)
@@ -25,10 +28,13 @@ import Grease.Options (SimOpts (simEnableDebugInfoPreconditions))
 import Grease.Options qualified as GO
 import Grease.Panic (panic)
 import Grease.Requirement (displayReq, reqParser)
+import Grease.Shape.Simple (SimpleShape)
+import Grease.Shape.Simple qualified as Simple
 import Grease.Solver (Solver (..))
 import Grease.Version (verStr)
 import Options.Applicative qualified as Opt
 import Text.Megaparsec qualified as TM
+import Text.Megaparsec.Char qualified as TMP
 
 megaparsecReader :: TM.Parsec Void Text a -> Opt.ReadM a
 megaparsecReader p = Opt.eitherReader $ \rawStr ->
@@ -104,6 +110,16 @@ entrypointParser =
           <> Opt.metavar "SYMBOL:FILE"
           <> Opt.help "name of entrypoint symbol, and the path to its startup override (in Crucible S-expression syntax)"
       )
+
+simpleShapesParser :: Opt.Parser (Map Text SimpleShape)
+simpleShapesParser = fmap Map.fromList $ Opt.many $ do
+  let argName = Text.pack <$> TM.some TMP.alphaNumChar
+  Opt.option
+    (megaparsecReader ((,) <$> argName <*> (TM.chunk ":" *> Simple.parseUninit)))
+    ( Opt.long "arg-buf-uninit"
+        <> Opt.metavar "ARG:N"
+        <> Opt.help "initialize argument ARG to a pointer to an uninitialized buffer of N bytes"
+    )
 
 simOpts :: Opt.Parser GO.SimOpts
 simOpts = do
@@ -289,6 +305,7 @@ simOpts = do
               <> Opt.help "The path to the symbolic filesystem"
           )
       )
+  simSimpleShapes <- simpleShapesParser
   pure GO.SimOpts{..}
  where
   callOptionsGroup = "Call options"

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -524,6 +524,7 @@ initialLlvmFileSystem halloc sym simOpts = do
 -- 2. DWARF debug info (via 'loadDwarfPreconditions') if
 --    'simEnableDebugInfoPreconditions' is 'True'
 -- 3. A shape DSL file (via 'loadInitialPreconditions')
+-- 4. TODO(#228): Simple shapes
 --
 -- Later steps override earlier ones.
 macawInitArgShapes ::
@@ -1158,6 +1159,7 @@ simulateMacaw la halloc elf loadedProg mbPltStubInfo archCtx txtBounds simOpts p
 -- 2. DWARF debug info (via 'GLD.diArgShapes') if
 --    'simEnableDebugInfoPreconditions' is 'True'
 -- 3. A shape DSL file (via 'loadInitialPreconditions')
+-- 4. TODO(#228): Simple shapes
 --
 -- Later steps override earlier ones.
 llvmInitArgShapes ::

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -146,6 +146,7 @@ import Grease.Shape.Concretize (concShape)
 import Grease.Shape.NoTag (NoTag (NoTag))
 import Grease.Shape.Parse qualified as Parse
 import Grease.Shape.Pointer (PtrShape)
+import Grease.Shape.Simple qualified as Simple
 import Grease.Solver (withSolverOnlineBackend)
 import Grease.Syntax (parseOverridesYaml, parseProgram, parsedProgramCfgMap, resolveOverridesYaml)
 import Grease.Syscall
@@ -305,6 +306,23 @@ loadInitialPreconditions la preconds names initArgs =
       let addrWidth = MC.addrWidthRepr ?ptrWidth
       doLog la (Diag.LoadedPrecondition path addrWidth names precond)
       pure precond
+
+-- | Override 'Shape.ArgShapes' using 'Simple.SimpleShape's from the CLI
+useSimpleShapes ::
+  ExtShape ext ~ PtrShape ext w =>
+  Mem.HasPtrWidth w =>
+  MM.MemWidth w =>
+  -- | Argument names
+  Ctx.Assignment (Const.Const String) tys ->
+  -- | Initial arguments
+  Shape.ArgShapes ext NoTag tys ->
+  Map Text.Text Simple.SimpleShape ->
+  IO (Shape.ArgShapes ext NoTag tys)
+useSimpleShapes argNames initArgs simpleShapes = do
+  let parsedShapes = Parse.ParsedShapes (fmap Simple.toShape simpleShapes)
+  case Shape.replaceShapes argNames initArgs parsedShapes of
+    Left err -> throw (GreaseException (Text.pack (show (PP.pretty err))))
+    Right shapes -> pure shapes
 
 toBatchBug ::
   Mem.HasPtrWidth wptr =>
@@ -524,7 +542,7 @@ initialLlvmFileSystem halloc sym simOpts = do
 -- 2. DWARF debug info (via 'loadDwarfPreconditions') if
 --    'simEnableDebugInfoPreconditions' is 'True'
 -- 3. A shape DSL file (via 'loadInitialPreconditions')
--- 4. TODO(#228): Simple shapes
+-- 4. Simple shapes from the CLI (via 'useSimpleShapes')
 --
 -- Later steps override earlier ones.
 macawInitArgShapes ::
@@ -551,7 +569,7 @@ macawInitArgShapes ::
 macawInitArgShapes la bak archCtx simOpts macawCfgConfig argNames mbCfgAddr = do
   let memory = mcMemory macawCfgConfig
   let mdEntryAbsAddr = fmap (segoffToAbsoluteAddr memory) mbCfgAddr
-  initArgs_ <- minimalArgShapes bak archCtx mdEntryAbsAddr
+  initArgs0 <- minimalArgShapes bak archCtx mdEntryAbsAddr
   let shouldUseDwarf = simEnableDebugInfoPreconditions simOpts
   let getDwarfArgs = do
         elfHdr <- mcElf macawCfgConfig
@@ -561,11 +579,13 @@ macawInitArgShapes la bak archCtx simOpts macawCfgConfig argNames mbCfgAddr = do
           memory
           (simTypeUnrollingBound simOpts)
           argNames
-          initArgs_
+          initArgs0
           elfHdr
           archCtx
-  let dwarfedArgs = if shouldUseDwarf then fromMaybe initArgs_ getDwarfArgs else initArgs_
-  loadInitialPreconditions la (simInitialPreconditions simOpts) argNames dwarfedArgs
+  let dwarfedArgs = if shouldUseDwarf then fromMaybe initArgs0 getDwarfArgs else initArgs0
+  initArgs1 <-
+    loadInitialPreconditions la (simInitialPreconditions simOpts) argNames dwarfedArgs
+  useSimpleShapes argNames initArgs1 (simSimpleShapes simOpts)
 
 simulateMacawCfg ::
   forall sym bak arch solver scope st fm.
@@ -1159,7 +1179,7 @@ simulateMacaw la halloc elf loadedProg mbPltStubInfo archCtx txtBounds simOpts p
 -- 2. DWARF debug info (via 'GLD.diArgShapes') if
 --    'simEnableDebugInfoPreconditions' is 'True'
 -- 3. A shape DSL file (via 'loadInitialPreconditions')
--- 4. TODO(#228): Simple shapes
+-- 4. Simple shapes from the CLI (via 'useSimpleShapes')
 --
 -- Later steps override earlier ones.
 llvmInitArgShapes ::
@@ -1173,13 +1193,14 @@ llvmInitArgShapes ::
   IO (ArgShapes CLLVM.LLVM NoTag argTys)
 llvmInitArgShapes la simOpts llvmMod argNames cfg = do
   let argTys = C.cfgArgTypes cfg
-  initArgs_ <-
+  initArgs0 <-
     case llvmMod of
       Just m
         | simEnableDebugInfoPreconditions simOpts ->
             GLD.diArgShapes (C.handleName (C.cfgHandle cfg)) argTys m
       _ -> traverseFC (minimalShapeWithPtrs (pure . const NoTag)) argTys
-  loadInitialPreconditions la (simInitialPreconditions simOpts) argNames (ArgShapes initArgs_)
+  initArgs1 <- loadInitialPreconditions la (simInitialPreconditions simOpts) argNames (ArgShapes initArgs0)
+  useSimpleShapes argNames initArgs1 (simSimpleShapes simOpts)
 
 simulateLlvmCfg ::
   forall sym bak arch solver t st fm argTys ret.

--- a/grease-cli/tests/llvm/simple-shapes.llvm.cbl
+++ b/grease-cli/tests/llvm/simple-shapes.llvm.cbl
@@ -1,0 +1,14 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that simple shapes CLI flags are working for LLVM.
+
+(defun @test ((x0 (Ptr 64))) Unit
+  (start start:
+    (return ())))
+
+;; flags {"--symbol", "test"}
+;; flags {"--arg-buf-uninit", "%0:4"}
+;; go(prog)
+;; check "Using precondition:"
+;; check "%0: 000000+0000000000000000"
+;; check "000000: ## ## ## ##"

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -246,6 +246,7 @@ library
     Grease.Shape.NoTag
     Grease.Shape.Pointer
     Grease.Shape.Selector
+    Grease.Shape.Simple
     Grease.Shape.Parse
     Grease.Shape.Print
     Grease.Skip

--- a/grease/src/Grease/Options.hs
+++ b/grease/src/Grease/Options.hs
@@ -20,11 +20,15 @@ module Grease.Options (
   Opts (..),
 ) where
 
+import Data.Map.Strict (Map)
+import Data.Text (Text)
 import Data.Word (Word64)
 import Grease.Diagnostic.Severity (Severity)
 import Grease.Entrypoint
 import Grease.Macaw.PLT
 import Grease.Requirement (Requirement)
+import Grease.Shape.Pointer (ExtraStackSlots (..))
+import Grease.Shape.Simple (SimpleShape)
 import Grease.Solver (Solver (..))
 
 newtype TypeUnrollingBound = TypeUnrollingBound Int
@@ -55,12 +59,6 @@ data MutableGlobalState
 
 allMutableGlobalStates :: [MutableGlobalState]
 allMutableGlobalStates = [minBound .. maxBound]
-
--- | Allocate this many pointer-sized stack slots beyond the return address,
--- which are reserved for stack-spilled arguments.
-newtype ExtraStackSlots = ExtraStackSlots {getExtraStackSlots :: Int}
-  -- See Note [Derive Read/Show instances with the newtype strategy]
-  deriving newtype (Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 -- | If 'True', throw an error if attempting to call a symbolic function handle
 -- or pointer. If 'False', skip over such calls.
@@ -134,6 +132,8 @@ data SimOpts
   -- ^ Parse binary in raw binary mode (non-elf position dependent executable)
   , simRawBinaryOffset :: Word64
   -- ^ Load a raw binary at a given offset (will default to 0x0)
+  , simSimpleShapes :: Map Text SimpleShape
+  -- ^ Map from argument names to 'SimpleShape's for those arguments
   , simPltStubs :: [PltStub]
   -- ^ User-specified PLT stubs to consider in addition to the stubs that
   -- @grease@ discovers via heuristics.

--- a/grease/src/Grease/Shape/Pointer.hs
+++ b/grease/src/Grease/Shape/Pointer.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE ImplicitParams #-}
@@ -12,6 +13,7 @@
 -- Copyright        : (c) Galois, Inc. 2024
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Shape.Pointer (
+  ExtraStackSlots (..),
   TaggedByte (..),
   traverseTaggedByte,
   MemShape (..),
@@ -71,7 +73,6 @@ import Data.Word (Word8)
 import GHC.TypeLits (type Natural, type (<=))
 import Grease.Cursor
 import Grease.Cursor.Pointer (Dereference (..))
-import Grease.Options (ExtraStackSlots (..))
 import Grease.Shape.NoTag (NoTag (NoTag))
 import Grease.Utility
 import Lang.Crucible.CFG.Core qualified as C
@@ -79,6 +80,12 @@ import Lang.Crucible.LLVM.Bytes (Bytes (..))
 import Lang.Crucible.LLVM.Bytes qualified as Bytes
 import Lang.Crucible.LLVM.MemModel qualified as Mem
 import Prettyprinter qualified as PP
+
+-- | Allocate this many pointer-sized stack slots beyond the return address,
+-- which are reserved for stack-spilled arguments.
+newtype ExtraStackSlots = ExtraStackSlots {getExtraStackSlots :: Int}
+  -- See Note [Derive Read/Show instances with the newtype strategy]
+  deriving newtype (Enum, Eq, Integral, Num, Ord, Read, Real, Show)
 
 newtype BlockId = BlockId {getBlockId :: Int}
   deriving (Eq, Ord, Show)

--- a/grease/src/Grease/Shape/Simple.hs
+++ b/grease/src/Grease/Shape/Simple.hs
@@ -44,6 +44,7 @@ data SimpleShape
     RegInt32 !(BV 32)
   | -- | A 64-bit integer
     RegInt64 !(BV 64)
+  deriving Show
 
 -- | Parse a symbol from 'TM.Tokens'.
 symbol :: TM.Tokens Text -> TM.Parsec Void Text Text


### PR DESCRIPTION
Fixes #228. Based on #292 and #291. Needs:

- [ ] Some subset of:
  - [ ] `--arg-buf-init`
  - [ ] `--arg-int-32`
  - [ ] `--arg-int-64`
  - [ ] `--arg-str`
  - [ ] `--arg-buf-bytes`
- [ ] A test for Macaw S-expression CFGs