### PR TITLE
Use `\cases` syntax in a few places

### DIFF
--- a/grease/src/Grease/Shape.hs
+++ b/grease/src/Grease/Shape.hs
@@ -145,16 +145,16 @@ instance
   ) =>
   TestEquality (Shape ext tag)
   where
-  testEquality s s' =
-    case (s, s') of
-      (ShapeUnit tag, ShapeUnit tag') -> testEquality tag tag'
-      (ShapeBool tag, ShapeBool tag') -> testEquality tag tag'
-      (ShapeStruct tag fields, ShapeStruct tag' fields') ->
+  testEquality =
+    \cases
+      (ShapeUnit tag) (ShapeUnit tag') -> testEquality tag tag'
+      (ShapeBool tag) (ShapeBool tag') -> testEquality tag tag'
+      (ShapeStruct tag fields) (ShapeStruct tag' fields') ->
         case (testEquality tag tag', testEquality fields fields') of
           (Just Refl, Just Refl) -> Just Refl
           _ -> Nothing
-      (ShapeExt ext, ShapeExt ext') -> testEquality ext ext'
-      (_, _) -> Nothing
+      (ShapeExt ext) (ShapeExt ext') -> testEquality ext ext'
+      _ _ -> Nothing
 
 -- | Helper, not exported
 showTag :: ShowF tag => tag x -> String

--- a/grease/src/Grease/Shape/Pointer.hs
+++ b/grease/src/Grease/Shape/Pointer.hs
@@ -212,12 +212,12 @@ merge ::
   MemShape wptr tag ->
   MemShape wptr tag ->
   Maybe (MemShape wptr tag)
-merge s1 s2 =
-  case (s1, s2) of
-    (Uninitialized i, Uninitialized j) -> Just (Uninitialized (i + j))
-    (Initialized tagi i, Initialized tagj j) -> Just (Initialized (tagi <> tagj) (i + j))
-    (Exactly i, Exactly j) -> Just (Exactly (i List.++ j))
-    _ -> Nothing
+merge =
+  \cases
+    (Uninitialized i) (Uninitialized j) -> Just (Uninitialized (i + j))
+    (Initialized tagi i) (Initialized tagj j) -> Just (Initialized (tagi <> tagj) (i + j))
+    (Exactly i) (Exactly j) -> Just (Exactly (i List.++ j))
+    _ _ -> Nothing
 
 -- | Number of bytes required to store this 'MemShape'
 memShapeSize ::


### PR DESCRIPTION
I recently learned that [`\cases`] was included in [GHC 9.4], which  means we can use it freely in GREASE. This commit replaces a few spots where names were introduced just to tuple up two items that would immediately be `case`d.

[`\cases`]: https://github.com/ghc-proposals/ghc-proposals/blob/master/proposals/0302-cases.rst
[GHC 9.4]: https://downloads.haskell.org/~ghc/9.4.1/docs/users_guide/9.4.1-notes.html