### PR TITLE
Drop unnecessary `allow-newer`s from `cabal.project`

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,8 +1,3 @@
--- See https://github.com/Happstack/boomerang/issues/12
-allow-newer: boomerang:template-haskell
--- See https://github.com/travitch/haggle/issues/29
-allow-newer: haggle:primitive
-
 packages:
   grease/grease.cabal
   grease-cli/grease-cli.cabal


### PR DESCRIPTION
The upstream issues have all been fixed.

Fixes #347.