### PR TITLE
ci: Output HTML coverage report to job summary page

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,10 @@ jobs:
 
     - name: Report coverage
       shell: bash
-      run: ./scripts/coverage.sh
+      run: |
+        ./scripts/coverage.sh markup
+        cat hpc_index.html >> "${GITHUB_STEP_SUMMARY}"
+        ./scripts/coverage.sh
 
     - name: Test grease-diagrams
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -118,6 +118,7 @@ jobs:
       shell: bash
       run: |
         ./scripts/coverage.sh markup
+        echo '## HPC coverage results' >> "${GITHUB_STEP_SUMMARY}"
         echo '```' >> "${GITHUB_STEP_SUMMARY}"
         ./scripts/coverage.sh | tee -a "${GITHUB_STEP_SUMMARY}"
         echo '```' >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,13 +110,21 @@ jobs:
       shell: bash
       run: cabal test pkg:grease-cli
 
+    # This step will produce a Github-flavored Markdown report on the "job
+    # summary" page. The report will first contain the output of `hpc report`
+    # in a code block, followed by a collapsible "spoiler" containing the more
+    # detailed per-module information.
     - name: Report coverage
       shell: bash
       run: |
         ./scripts/coverage.sh markup
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
+        ./scripts/coverage.sh | tee -a "${GITHUB_STEP_SUMMARY}"
+        echo '```' >> "${GITHUB_STEP_SUMMARY}"
+        echo '<details><summary>Module-level summary</summary>' >> "${GITHUB_STEP_SUMMARY}"
         pip install beautifulsoup4==4.13.5
         ./scripts/coverage-scrape.py hpc_index.html >> "${GITHUB_STEP_SUMMARY}"
-        ./scripts/coverage.sh
+        echo '</details>' >> "${GITHUB_STEP_SUMMARY}"
 
     - name: Test grease-diagrams
       shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -114,7 +114,8 @@ jobs:
       shell: bash
       run: |
         ./scripts/coverage.sh markup
-        cat hpc_index.html >> "${GITHUB_STEP_SUMMARY}"
+        pip install beautifulsoup4==4.13.5
+        ./scripts/coverage-scrape.py hpc_index.html >> "${GITHUB_STEP_SUMMARY}"
         ./scripts/coverage.sh
 
     - name: Test grease-diagrams

--- a/scripts/coverage-scrape.py
+++ b/scripts/coverage-scrape.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Scrape just the HTML table from an HPC report.
+#
+# Requires beautifulsoup4, try `pip install beautifulsoup4==4.13.5`.
+
+from argparse import ArgumentParser
+from bs4 import BeautifulSoup
+from pathlib import Path
+
+
+def go(path: Path, /):
+    html = path.read_text()
+    soup = BeautifulSoup(html, "html.parser")
+    table = soup.find("table", class_="dashboard")
+    print(table)
+
+
+parser = ArgumentParser()
+parser.add_argument("path", type=Path)
+args = parser.parse_args()
+go(args.path)


### PR DESCRIPTION
Adds a coverage overview to the "job summary" page, see [this run](https://github.com/GaloisInc/grease/actions/runs/17498093231). This overview is not *optimal*, because I'm just `cat`ing an entire HTML document (with a header, styling, etc.) into a file that gets displayed as GitHub-flavored Markdown. This results in (1) some garbage at the top, (2) blank "progress" bars, and (3) dead links. I personally think all this is fine, although we could consider doing some light Python scripting to extract just the table. We could do that up-front or an a follow-up.

It would also be nice to package up the whole report as an artifact that developers can download, I'll do that next.

See:

- https://github.blog/news-insights/product-news/supercharging-github-actions-with-job-summaries/
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary