### PR TITLE
Expose more Macaw CFG type-checking functionality

### DIFF
--- a/grease/src/Grease/Macaw/Entrypoint.hs
+++ b/grease/src/Grease/Macaw/Entrypoint.hs
@@ -79,19 +79,8 @@ checkMacawEntrypointCfgsSignatures archCtx entrypointCfgs = do
       }
 
 throwMacawCfgTypecheckError ::
-  Either
-    MacawCfgTypecheckError
-    ( C.Reg.SomeCFG
-        (Symbolic.MacawExt arch)
-        (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch)
-        (Symbolic.ArchRegStruct arch)
-    ) ->
-  IO
-    ( C.Reg.SomeCFG
-        (Symbolic.MacawExt arch)
-        (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch)
-        (Symbolic.ArchRegStruct arch)
-    )
+  Either MacawCfgTypecheckError a ->
+  IO a
 throwMacawCfgTypecheckError =
   \case
     Right ok -> pure ok


### PR DESCRIPTION
Follow-up to #359, expose lower-level functionality with a structured error type to make it more usable by downstream clients.