### PR TITLE
Allow address overrides to abort

### DIFF
--- a/doc/overrides.md
+++ b/doc/overrides.md
@@ -298,7 +298,7 @@ will be passed the current contents of the registers.
 
 Address overrides are subject to a few limitations:
 
-- They must terminate and return a total result.
+- They must terminate and return a total result, or they must abort.
 - They may not modify memory.
 
 <!-- Copyright (c) Galois, Inc. 2024. -->

--- a/grease/src/Grease/Macaw/Overrides/Address.hs
+++ b/grease/src/Grease/Macaw/Overrides/Address.hs
@@ -266,13 +266,13 @@ runAddressOverride crucState someCfg = do
     toInitialState crucState C.UnitRepr $
       C.runOverrideSim C.UnitRepr $
         C.regValue <$> C.callCFG cfg regs
-  C.withBackend (C.execStateContext initState) $ \bak -> do
+  C.withBackend (C.execStateContext initState) $ \_bak -> do
     execResult <- C.executeCrucible [] initState
     case execResult of
       C.FinishedResult _ (C.TotalRes{}) -> pure ()
-      C.AbortedResult _ (C.AbortedExec (C.AssertionFailure simErr) _) ->
-        C.addFailedAssertion bak (C.simErrorReason simErr)
-      _ -> X.throw (GreaseException "Address override did not terminate successfully")
+      C.AbortedResult _ (C.AbortedExec reason _) -> C.abortExecBecause reason
+      _ ->
+        X.throw (GreaseException "Address override did not return a result nor abort")
 
 tryRunAddressOverride ::
   ( sym ~ W4.ExprBuilder t st fs


### PR DESCRIPTION
Previously, GREASE added an extraneous extra failing proof obligation if an override aborted with `AssertionFailure`. This led to some confusing behavior around concretization, where data was concretized for the proof obligation `false`. Instead, simply re-raise *any* abort reason that comes from an address override.