### PR TITLE
Fix handling of timeouts, duplicated `--timeout` flag

### DIFF
--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -146,7 +146,7 @@ boundsOptsParser = Opt.parserOptionGroup "Bounds, limits, and timeouts" $ do
     Timeout . secondsFromInt
       <$> Opt.option
         Opt.auto
-        ( Opt.long "timeout"
+        ( Opt.long "solver-timeout"
             <> Opt.help "solver timeout (in seconds)"
             <> Opt.metavar "SECS"
             <> Opt.showDefault

--- a/grease-cli/src/Grease/Main.hs
+++ b/grease-cli/src/Grease/Main.hs
@@ -992,8 +992,6 @@ simulateRewrittenCfg la bak fm halloc macawCfgConfig archCtx simOpts setupHook a
       pure (BatchCantRefine b)
     RefinementItersExceeded ->
       pure BatchItersExceeded
-    RefinementTimeout ->
-      pure BatchTimeout
     RefinementNoHeuristic errs -> do
       maybeBug <- checkMustFail bak errs
       case maybeBug of
@@ -1497,8 +1495,6 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
       pure (BatchCantRefine b)
     RefinementItersExceeded ->
       pure BatchItersExceeded
-    RefinementTimeout ->
-      pure BatchTimeout
     RefinementNoHeuristic errs -> do
       maybeBug <- checkMustFail bak errs
       case maybeBug of

--- a/grease-cli/tests/ux/timeout.llvm.cbl
+++ b/grease-cli/tests/ux/timeout.llvm.cbl
@@ -1,0 +1,13 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Test the UX of timeouts.
+
+;; flags {"--symbol", "test"}
+;; flags {"--loop-bound", "100000000"}
+;; flags {"--timeout", "1"}
+;; go(prog)
+
+(defun @test () Unit
+  (start start:
+    (jump start:)))
+;; check "Symbolic execution timed out!"

--- a/grease/src/Grease/Heuristic/Result.hs
+++ b/grease/src/Grease/Heuristic/Result.hs
@@ -23,6 +23,7 @@ data CantRefine
   = MissingFunc (Maybe String)
   | MissingSemantics Text
   | MutableGlobal String
+  | Timeout
   deriving (Generic, Show)
 
 instance Aeson.ToJSON CantRefine
@@ -34,6 +35,7 @@ instance PP.Pretty CantRefine where
       MissingFunc Nothing -> "Missing implementation for function"
       MissingSemantics msg -> PP.pretty msg
       MutableGlobal name -> "Load from mutable global " PP.<> PP.pretty name
+      Timeout -> "Symbolic execution timed out"
 
 data HeuristicResult ext tys
   = CantRefine CantRefine

--- a/grease/src/Grease/Output.hs
+++ b/grease/src/Grease/Output.hs
@@ -86,7 +86,6 @@ data BatchStatus
   | BatchItersExceeded
   | BatchChecks (Map Requirement CheckStatus)
   | BatchCantRefine CantRefine
-  | BatchTimeout
   deriving (Show, Generic)
 
 instance Aeson.ToJSON BatchStatus
@@ -133,7 +132,6 @@ instance PP.Pretty BatchStatus where
   pretty BatchItersExceeded =
     "Failed to infer precondition; maximum iterations exceeded"
   pretty (BatchCantRefine b) = PP.pretty b
-  pretty BatchTimeout = "Exceeded timeout!"
 
 -- | A 'BatchStatus' and any other information that is useful to report (e.g.,
 -- for consumption by tools that use @grease@'s JSON output).


### PR DESCRIPTION
#379 changed the way timeouts work, but this exposed an issue in the way we didn't handle `TimeoutResult`s from Crucible. This PR fixes the bug and adds a test. It also fixes duplication of the `--timeout` CLI flag.