### PR TITLE
Abort path instead of throwing an exception on unsupported relocations

### DIFF
--- a/grease-cli/tests/llvm/exit.llvm.cbl
+++ b/grease-cli/tests/llvm/exit.llvm.cbl
@@ -10,4 +10,4 @@
 	(let p (ptr 32 0 (bv 32 0)))
     (funcall h p)
     (return ())))
-;; ok()
+;; check "Program exited"

--- a/grease/src/Grease/Heuristic/Result.hs
+++ b/grease/src/Grease/Heuristic/Result.hs
@@ -20,10 +20,13 @@ import Prettyprinter qualified as PP
 
 -- | There is no way to proceed with refinement, for some explicit reason
 data CantRefine
-  = MissingFunc (Maybe String)
+  = Exhausted String
+  | Exit (Maybe Int)
+  | MissingFunc (Maybe String)
   | MissingSemantics Text
   | MutableGlobal String
   | Timeout
+  | Unsupported String
   deriving (Generic, Show)
 
 instance Aeson.ToJSON CantRefine
@@ -31,11 +34,15 @@ instance Aeson.ToJSON CantRefine
 instance PP.Pretty CantRefine where
   pretty =
     \case
+      Exhausted msg -> "Resource exhausted:" PP.<+> PP.pretty msg
+      Exit (Just code) -> "Program exited with" PP.<> PP.pretty code
+      Exit Nothing -> "Program exited"
       MissingFunc (Just nm) -> "Missing implementation for '" PP.<> PP.pretty nm PP.<> "'"
       MissingFunc Nothing -> "Missing implementation for function"
       MissingSemantics msg -> PP.pretty msg
       MutableGlobal name -> "Load from mutable global " PP.<> PP.pretty name
       Timeout -> "Symbolic execution timed out"
+      Unsupported msg -> "Unsupported:" PP.<+> PP.pretty msg
 
 data HeuristicResult ext tys
   = CantRefine CantRefine

--- a/grease/src/Grease/Heuristic/Result.hs
+++ b/grease/src/Grease/Heuristic/Result.hs
@@ -21,8 +21,10 @@ import Prettyprinter qualified as PP
 -- | There is no way to proceed with refinement, for some explicit reason
 data CantRefine
   = Exhausted String
-  | Exit (Maybe Int)
-  | MissingFunc (Maybe String)
+  | -- | optional exit code
+    Exit (Maybe Int)
+  | -- | optional function name
+    MissingFunc (Maybe String)
   | MissingSemantics Text
   | MutableGlobal String
   | Timeout


### PR DESCRIPTION
Most unsupported features (e.g., instructions without semantics) cause individual symex paths to abort. This is nice because we can continue to explore other paths, and GREASE might even abduce a precondition that avoids the problematic path after all. Additionally, we can continue to analyze other functions in the binary.

Unsupported relocations were previously handled by throwing an uncaught exception. This commit brings them in line with those other unsupported features for all of the reasons described above.

This commit also causes GREASE to be more conservative about what it calls a refinement success in a few suspicious cases. This will hopefully allow us to avoid some more bugs along the lines of the one fixed in #380.