### PR TITLE
Errors

### DIFF
--- a/grease-aarch32/src/Grease/Macaw/Arch/AArch32.hs
+++ b/grease-aarch32/src/Grease/Macaw/Arch/AArch32.hs
@@ -23,12 +23,12 @@ import Data.Parameterized.NatRepr (knownNat)
 import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word32)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.RegName (RegName (..))
 import Grease.Options (ExtraStackSlots)
 import Grease.Shape.Pointer (armStackPtrShape)
-import Grease.Utility (GreaseException (..))
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.LLVM.MemModel qualified as Mem
 import Lang.Crucible.Simulator.RegValue qualified as C

--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -110,6 +110,7 @@ import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic
 import Grease.Diagnostic.Severity (Severity)
 import Grease.Entrypoint
+import Grease.Error (GreaseException (GreaseException))
 import Grease.ExecutionFeatures (greaseExecFeats)
 import Grease.Heuristic
 import Grease.LLVM qualified as LLVM

--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -188,6 +188,7 @@ import Lumberjack qualified as LJ
 import Prettyprinter qualified as PP
 import Prettyprinter.Render.Text qualified as PP
 import System.Directory (Permissions, getPermissions)
+import System.Exit as Exit
 import System.FilePath (FilePath)
 import System.IO (IO)
 import Text.LLVM qualified as L
@@ -219,12 +220,12 @@ doLog la diag = LJ.writeLog la (MainDiagnostic diag)
 malformedElf :: GreaseLogAction -> PP.Doc Void -> IO a
 malformedElf la doc = do
   doLog la (Diag.MalformedElf doc)
-  throw (GreaseException (Text.pack (show doc)))
+  Exit.exitFailure
 
 userError :: GreaseLogAction -> PP.Doc Void -> IO a
 userError la doc = do
   doLog la (Diag.UserError doc)
-  throw (GreaseException (Text.pack (show ("user error:" PP.<+> doc))))
+  Exit.exitFailure
 
 -- | Read a binary's file permissions and ELF header info.
 readElfHeaderInfo ::

--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -1336,7 +1336,7 @@ simulateMacaw la halloc elf loadedProg mbPltStubInfo archCtx txtBounds simOpts p
   -- requirement). This check only applies to dynamically linked binaries, and
   -- for statically linked binaries, this map will be empty.
   pltStubSegOffToNameMap <-
-    resolvePltStubs mbPltStubInfo loadOpts elf symbolRelocs (simPltStubs simOpts) memory
+    resolvePltStubs (simProgPath simOpts) mbPltStubInfo loadOpts elf symbolRelocs (simPltStubs simOpts) memory
 
   let
     -- The inverse of `pltStubSegOffToNameMap`.

--- a/grease-exe/tests/sanity/xfail-panic/empty/test.c
+++ b/grease-exe/tests/sanity/xfail-panic/empty/test.c
@@ -6,4 +6,5 @@
 // all: flags {"--symbol", "test"}
 // all: go(prog)
 
-// all: check [[Exception: Could not find entrypoint symbol "test"]]
+// all: exception()
+// all: check [[user error: Could not find entrypoint symbol "test"]]

--- a/grease-exe/tests/sanity/xfail-panic/empty/test.c
+++ b/grease-exe/tests/sanity/xfail-panic/empty/test.c
@@ -6,5 +6,4 @@
 // all: flags {"--symbol", "test"}
 // all: go(prog)
 
-// all: exception()
-// all: check [[user error: Could not find entrypoint symbol "test"]]
+// all: user_error [[Could not find entrypoint symbol "test"]]

--- a/grease-exe/tests/test.lua
+++ b/grease-exe/tests/test.lua
@@ -2,6 +2,13 @@ function ok() check 'All goals passed' end
 
 function exception() check 'Exception: ' end
 
+function user_error(msg)
+  check 'User error: '
+  check(msg)
+  exception()
+  check 'ExitFailure 1'
+end
+
 function could_not_infer() check 'Possible bug(s)' end
 
 function must_fail() check 'Likely bug: unavoidable error' end

--- a/grease-exe/tests/ux/addr-override-bad-address.lua
+++ b/grease-exe/tests/ux/addr-override-bad-address.lua
@@ -3,5 +3,4 @@
 path = "tests/refine/pos/extra/addr-override.x64.cbl"
 flags {"--addr-override", "0x99999999:" .. path}
 go "tests/refine/pos/compare_to_null/test.x64.elf" 
-exception()
-check("user error: Bad address: 0x99999999 at " .. path)
+user_error("Bad address: 0x99999999 at " .. path)

--- a/grease-exe/tests/ux/addr-override-bad-args.lua
+++ b/grease-exe/tests/ux/addr-override-bad-args.lua
@@ -3,5 +3,4 @@
 path = "tests/ux/extra/addr-override-bad-args.x64.cbl"
 flags {"--addr-override", "0x401000:" .. path}
 go "tests/refine/pos/compare_to_null/test.x64.elf" 
-exception()
-check("user error: Bad address override argument types at " .. path)
+user_error("Bad address override argument types at " .. path)

--- a/grease-exe/tests/ux/addr-override-bad-return.lua
+++ b/grease-exe/tests/ux/addr-override-bad-return.lua
@@ -3,5 +3,4 @@
 path = "tests/ux/extra/addr-override-bad-return.x64.cbl"
 flags {"--addr-override", "0x401000:" .. path}
 go "tests/refine/pos/compare_to_null/test.x64.elf" 
-exception()
-check("user error: Bad address override return type at " .. path)
+user_error("Bad address override return type at " .. path)

--- a/grease-exe/tests/ux/addr-override-function-not-found.lua
+++ b/grease-exe/tests/ux/addr-override-function-not-found.lua
@@ -3,5 +3,4 @@
 path = "tests/ux/extra/addr-override-function-not-found.x64.cbl"
 flags {"--addr-override", "0x401000:" .. path}
 go "tests/refine/pos/compare_to_null/test.x64.elf"
-exception()
-check "user error: Expected to find a function named 'addr-override-function-not-found'"
+user_error "Expected to find a function named 'addr-override-function-not-found'"

--- a/grease-exe/tests/ux/addr-override-multiple-functions.lua
+++ b/grease-exe/tests/ux/addr-override-multiple-functions.lua
@@ -3,5 +3,4 @@
 path = "tests/ux/extra/addr-override-multiple-functions.x64.cbl"
 flags {"--addr-override", "0x401000:" .. path}
 go "tests/refine/pos/compare_to_null/test.x64.elf" 
-exception()
-check "user error: Override contains multiple 'addr-override-multiple-functions' functions"
+user_error "Override contains multiple 'addr-override-multiple-functions' functions"

--- a/grease-exe/tests/ux/overrides-yaml-bad-key.x64.cbl
+++ b/grease-exe/tests/ux/overrides-yaml-bad-key.x64.cbl
@@ -8,8 +8,8 @@
   (start start:
     (return regs)))
 
-;; exception()
-;; check [[
-;; user error: Unexpected keys in overrides.yaml file:
-;; - funktion addres overides]]
+;; user_error [[
+;; Unexpected keys in overrides.yaml file:
+;; - funktion addres overides
+;; ]]
 

--- a/grease-exe/tests/ux/overrides-yaml-bad-key.x64.cbl
+++ b/grease-exe/tests/ux/overrides-yaml-bad-key.x64.cbl
@@ -8,8 +8,8 @@
   (start start:
     (return regs)))
 
+;; exception()
 ;; check [[
-;; Unexpected keys in overrides.yaml file:
-;; - funktion addres overides
-;; ]]
+;; user error: Unexpected keys in overrides.yaml file:
+;; - funktion addres overides]]
 

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
@@ -22,12 +22,13 @@ import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word32)
 import Dismantle.PPC qualified as D
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.RegName (RegName (..))
 import Grease.Options (ExtraStackSlots)
 import Grease.Shape.Pointer (ppcStackPtrShape)
-import Grease.Utility (GreaseException (..), bytes32LE)
+import Grease.Utility (bytes32LE)
 import Lang.Crucible.LLVM.MemModel qualified as Mem
 import Lang.Crucible.Simulator.RegValue qualified as C
 import Stubs.FunctionOverride.PPC.Linux qualified as Stubs

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC32.hs
@@ -10,7 +10,6 @@
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Macaw.Arch.PPC32 (ppc32Ctx) where
 
-import Control.Exception.Safe (throw)
 import Data.BitVector.Sized qualified as BV
 import Data.ElfEdit qualified as EE
 import Data.Macaw.PPC qualified as PPC
@@ -22,11 +21,11 @@ import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word32)
 import Dismantle.PPC qualified as D
-import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.RegName (RegName (..))
 import Grease.Options (ExtraStackSlots)
+import Grease.Panic (panic)
 import Grease.Shape.Pointer (ppcStackPtrShape)
 import Grease.Utility (bytes32LE)
 import Lang.Crucible.LLVM.MemModel qualified as Mem
@@ -54,7 +53,9 @@ ppc32Ctx ::
 ppc32Ctx mbReturnAddr stackArgSlots = do
   let extOverride = Stubs.ppcLinuxStmtExtensionOverride
   avals <- case Symbolic.genArchVals Proxy Proxy (Just extOverride) of
-    Nothing -> throw $ GreaseException "Failed to generate architecture-specific values"
+    Nothing ->
+      -- `genArchVals` is total: https://github.com/GaloisInc/macaw/issues/231
+      panic "ppc32Ctx" ["Failed to generate architecture-specific values"]
     Just avals -> pure avals
   let regOverrides =
         case mbReturnAddr of

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
@@ -10,7 +10,6 @@
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Macaw.Arch.PPC64 (ppc64Ctx) where
 
-import Control.Exception.Safe (throw)
 import Data.BitVector.Sized qualified as BV
 import Data.ElfEdit qualified as EE
 import Data.Macaw.BinaryLoader qualified as Loader
@@ -23,11 +22,11 @@ import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import Dismantle.PPC qualified as D
-import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.RegName (RegName (..))
 import Grease.Options (ExtraStackSlots)
+import Grease.Panic (panic)
 import Grease.Shape.Pointer (ppcStackPtrShape)
 import Grease.Utility (bytes64LE)
 import Lang.Crucible.LLVM.MemModel qualified as Mem
@@ -61,7 +60,9 @@ ppc64Ctx ::
 ppc64Ctx mbReturnAddr stackArgSlots loadedBinary = do
   let extOverride = Stubs.ppcLinuxStmtExtensionOverride
   avals <- case Symbolic.genArchVals Proxy Proxy (Just extOverride) of
-    Nothing -> throw $ GreaseException "Failed to generate architecture-specific values"
+    Nothing ->
+      -- `genArchVals` is total: https://github.com/GaloisInc/macaw/issues/231
+      panic "ppc64Ctx" ["Failed to generate architecture-specific values"]
     Just avals -> pure avals
   let regOverrides =
         case mbReturnAddr of

--- a/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
+++ b/grease-ppc/src/Grease/Macaw/Arch/PPC64.hs
@@ -23,12 +23,13 @@ import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
 import Dismantle.PPC qualified as D
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchReloc)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.RegName (RegName (..))
 import Grease.Options (ExtraStackSlots)
 import Grease.Shape.Pointer (ppcStackPtrShape)
-import Grease.Utility (GreaseException (..), bytes64LE)
+import Grease.Utility (bytes64LE)
 import Lang.Crucible.LLVM.MemModel qualified as Mem
 import Lang.Crucible.Simulator.RegValue qualified as C
 import Stubs.FunctionOverride.PPC.Linux qualified as Stubs

--- a/grease-x86/src/Grease/Macaw/Arch/X86.hs
+++ b/grease-x86/src/Grease/Macaw/Arch/X86.hs
@@ -10,7 +10,6 @@
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Macaw.Arch.X86 (x86Ctx) where
 
-import Control.Exception.Safe (throw)
 import Control.Monad.IO.Class (MonadIO (..))
 import Data.BitVector.Sized qualified as BV
 import Data.ElfEdit qualified as EE
@@ -22,11 +21,11 @@ import Data.Parameterized.NatRepr qualified as NatRepr
 import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
-import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchRegs, ArchReloc)
 import Grease.Macaw.Arch.X86.Reg (getX86Reg, modifyX86Reg)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Options (ExtraStackSlots)
+import Grease.Panic (panic)
 import Grease.Shape.Pointer (x64StackPtrShape)
 import Grease.Utility (bytes64LE)
 import Lang.Crucible.Backend qualified as C
@@ -65,7 +64,9 @@ x86Ctx halloc mbReturnAddr stackArgSlots = do
   let extOverride =
         Stubs.x86_64LinuxStmtExtensionOverride fsbaseGlob gsbaseGlob
   avals <- case Symbolic.genArchVals Proxy Proxy (Just extOverride) of
-    Nothing -> throw $ GreaseException "Failed to generate architecture-specific values"
+    Nothing ->
+      -- `genArchVals` is total: https://github.com/GaloisInc/macaw/issues/231
+      panic "armCtx" ["Failed to generate architecture-specific values"]
     Just avals -> pure avals
   return
     ArchContext

--- a/grease-x86/src/Grease/Macaw/Arch/X86.hs
+++ b/grease-x86/src/Grease/Macaw/Arch/X86.hs
@@ -22,12 +22,13 @@ import Data.Parameterized.NatRepr qualified as NatRepr
 import Data.Parameterized.Some qualified as Some
 import Data.Proxy (Proxy (..))
 import Data.Word (Word64)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext (..), ArchRegs, ArchReloc)
 import Grease.Macaw.Arch.X86.Reg (getX86Reg, modifyX86Reg)
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Options (ExtraStackSlots)
 import Grease.Shape.Pointer (x64StackPtrShape)
-import Grease.Utility (GreaseException (..), bytes64LE)
+import Grease.Utility (bytes64LE)
 import Lang.Crucible.Backend qualified as C
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.LLVM.MemModel qualified as Mem

--- a/grease-x86/src/Grease/Macaw/Arch/X86/Reg.hs
+++ b/grease-x86/src/Grease/Macaw/Arch/X86/Reg.hs
@@ -14,7 +14,7 @@ import Data.Macaw.X86.Symbolic qualified as X86Sym
 import Data.Macaw.X86.X86Reg qualified as X86
 import Data.Parameterized.Context qualified as Ctx
 import Data.Text qualified as Text
-import Grease.Utility (GreaseException (..))
+import Grease.Error (GreaseException (GreaseException))
 import Prelude hiding (mod)
 
 -- | Retrieve the value of an x86 register, throwing a 'GreaseException' if it

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -201,6 +201,7 @@ library
     Grease.Cursor.Pointer
     Grease.Diagnostic
     Grease.Diagnostic.Severity
+    Grease.Error
     Grease.ErrorDescription
     Grease.Entrypoint
     Grease.ExecutionFeatures

--- a/grease/src/Grease/Entrypoint.hs
+++ b/grease/src/Grease/Entrypoint.hs
@@ -38,8 +38,8 @@ import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Void (Void)
 import Data.Word (Word64)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Syntax (parseProgram, parsedProgramCfgMap)
-import Grease.Utility (GreaseException (..))
 import Lang.Crucible.CFG.Core qualified as C
 import Lang.Crucible.CFG.Extension qualified as C
 import Lang.Crucible.CFG.Reg qualified as C.Reg

--- a/grease/src/Grease/Error.hs
+++ b/grease/src/Grease/Error.hs
@@ -1,0 +1,18 @@
+-- |
+-- Copyright   : (c) Galois, Inc. 2025
+-- Maintainer  : GREASE Maintainers <grease@galois.com>
+-- Module      : Grease.Error
+-- Description : Error handling
+module Grease.Error (
+  GreaseException (..),
+) where
+
+import Control.Exception.Safe qualified as X
+import Data.Text (Text)
+import Data.Text qualified as Text
+
+-- TODO(#4): Come up with a more thoughtful error handling scheme
+newtype GreaseException = GreaseException Text
+instance X.Exception GreaseException
+instance Show GreaseException where
+  show (GreaseException msg) = Text.unpack msg

--- a/grease/src/Grease/Error.hs
+++ b/grease/src/Grease/Error.hs
@@ -5,6 +5,7 @@
 -- Description : Error handling
 module Grease.Error (
   GreaseException (..),
+  MalformedBinary (..),
 ) where
 
 import Control.Exception.Safe qualified as X
@@ -16,3 +17,13 @@ newtype GreaseException = GreaseException Text
 instance X.Exception GreaseException
 instance Show GreaseException where
   show (GreaseException msg) = Text.unpack msg
+
+data MalformedBinary
+  = MalformedBinary
+  { badBinaryPath :: FilePath
+  , badBinaryError :: Text
+  }
+instance X.Exception MalformedBinary
+instance Show MalformedBinary where
+  show (MalformedBinary path err) =
+    "Malformed binary at '" ++ path ++ "': " ++ Text.unpack err

--- a/grease/src/Grease/Heuristic.hs
+++ b/grease/src/Grease/Heuristic.hs
@@ -24,7 +24,7 @@ module Grease.Heuristic (
 ) where
 
 import Control.Applicative (Alternative ((<|>)), Const (..))
-import Control.Exception.Safe (MonadThrow, throw)
+import Control.Exception.Safe (MonadThrow)
 import Control.Lens (Lens', (.~), (^.))
 import Data.BitVector.Sized qualified as BV
 import Data.Bool qualified as Bool
@@ -46,12 +46,12 @@ import Grease.Bug.UndefinedBehavior qualified as UB
 import Grease.Cursor qualified as Cursor
 import Grease.Cursor.Pointer (Dereference)
 import Grease.Diagnostic
-import Grease.Error (GreaseException (GreaseException))
 import Grease.ErrorDescription (ErrorDescription (..))
 import Grease.Heuristic.Diagnostic qualified as Diag
 import Grease.Heuristic.Result
 import Grease.Macaw.RegName (RegNames, getRegName, mkRegName)
 import Grease.MustFail qualified as MustFail
+import Grease.Panic (panic)
 import Grease.Setup
 import Grease.Setup.Annotations qualified as Anns
 import Grease.Shape
@@ -218,7 +218,7 @@ assertPtrWidth ::
   m (w C.:~: wptr)
 assertPtrWidth ptr =
   case testPtrWidth ptr of
-    Nothing -> throw (GreaseException "Non-pointer-width pointer in memory op?")
+    Nothing -> panic "assertPtrWidth" ["Non-pointer-width pointer in memory op?"]
     Just r -> pure r
 
 allocInfoLoc ::

--- a/grease/src/Grease/Heuristic.hs
+++ b/grease/src/Grease/Heuristic.hs
@@ -46,6 +46,7 @@ import Grease.Bug.UndefinedBehavior qualified as UB
 import Grease.Cursor qualified as Cursor
 import Grease.Cursor.Pointer (Dereference)
 import Grease.Diagnostic
+import Grease.Error (GreaseException (GreaseException))
 import Grease.ErrorDescription (ErrorDescription (..))
 import Grease.Heuristic.Diagnostic qualified as Diag
 import Grease.Heuristic.Result
@@ -57,7 +58,7 @@ import Grease.Shape
 import Grease.Shape.NoTag (NoTag (NoTag))
 import Grease.Shape.Pointer
 import Grease.Shape.Selector
-import Grease.Utility (GreaseException (..), OnlineSolverAndBackend, ppProgramLoc, tshow)
+import Grease.Utility (OnlineSolverAndBackend, ppProgramLoc, tshow)
 import Lang.Crucible.Backend qualified as C
 import Lang.Crucible.CFG.Core qualified as C
 import Lang.Crucible.CFG.Extension qualified as C

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -318,7 +318,7 @@ minimalArgShapes _bak arch mbEntryAddr = do
             MT.BVTypeRepr w ->
               case testEquality w $ MT.knownNat @(MC.ArchAddrWidth arch) of
                 Just C.Refl -> pure (ShapeExt (arch ^. archStackPtrShape))
-                Nothing -> throw $ GreaseException "Bad stack pointer width"
+                Nothing -> panic "minimalArgShapes" ["Bad stack pointer width"]
       | Just Refl <- testEquality r MC.ip_reg
       , Just ipVal <- mbEntryAddr ->
           case MT.typeRepr r of
@@ -327,7 +327,7 @@ minimalArgShapes _bak arch mbEntryAddr = do
                 Just C.Refl ->
                   let bv = BV.mkBV w (fromIntegral (EL.memWordValue ipVal))
                    in pure (ShapeExt (ShapePtrBVLit NoTag w bv))
-                Nothing -> throw $ GreaseException "Bad instruction pointer width"
+                Nothing -> panic "minimalArgShapes" ["Bad stack pointer width"]
       | otherwise -> do
           shape <- case MT.typeRepr r of
             MT.BoolTypeRepr -> pure (ShapeBool NoTag)

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -49,6 +49,7 @@ import Data.Word (Word64, Word8)
 import GHC.Stack (HasCallStack, callStack)
 import Grease.Concretize.ToConcretize (HasToConcretize)
 import Grease.Diagnostic
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch
 import Grease.Macaw.Load.Relocation (RelocType (..))
 import Grease.Macaw.Overrides.Address (AddressOverrides)

--- a/grease/src/Grease/Macaw/Entrypoint.hs
+++ b/grease/src/Grease/Macaw/Entrypoint.hs
@@ -21,9 +21,9 @@ import Data.Text qualified as Text
 import Data.Traversable (for)
 import Data.Type.Equality (testEquality, (:~:) (Refl))
 import Grease.Entrypoint qualified as GE
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw (regStructRepr)
 import Grease.Macaw.Arch (ArchContext)
-import Grease.Utility (GreaseException (..))
 import Lang.Crucible.CFG.Reg qualified as C.Reg
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.Types qualified as CT

--- a/grease/src/Grease/Macaw/Load.hs
+++ b/grease/src/Grease/Macaw/Load.hs
@@ -37,6 +37,7 @@ import Data.Tuple qualified as Tuple
 import Data.Vector qualified as Vec
 import Grease.Diagnostic
 import Grease.Entrypoint (Entrypoint (..), EntrypointLocation (..))
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Load.Diagnostic qualified as Diag
 import Grease.Utility
 import Lang.Crucible.CFG.Core qualified as C

--- a/grease/src/Grease/Macaw/Load/Relocation.hs
+++ b/grease/src/Grease/Macaw/Load/Relocation.hs
@@ -18,7 +18,8 @@ import Data.Map.Strict qualified as Map
 import Data.Maybe (fromMaybe, listToMaybe)
 import Data.Vector qualified as Vec
 import Data.Word (Word32)
-import Grease.Utility (GreaseException (..), tshow)
+import Grease.Error (GreaseException (GreaseException))
+import Grease.Utility (tshow)
 
 -- | An architecture-independent description of the type of a relocation. When
 -- appropriate, this groups together certain relocation types that have

--- a/grease/src/Grease/Macaw/Overrides/Address.hs
+++ b/grease/src/Grease/Macaw/Overrides/Address.hs
@@ -34,12 +34,13 @@ import Data.Text qualified as Text
 import Data.Type.Equality (testEquality, (:~:) (Refl))
 import Data.Void (Void)
 import Grease.Concretize.ToConcretize (HasToConcretize)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.Arch (ArchContext, archVals)
 import Grease.Macaw.Overrides qualified as GMO
 import Grease.Macaw.Overrides.SExp (MacawSExpOverride)
 import Grease.Overrides (OverrideNameError (..), partitionCfgs)
 import Grease.Syntax (parseProgram)
-import Grease.Utility (GreaseException (GreaseException), tshow)
+import Grease.Utility (tshow)
 import Lang.Crucible.Backend qualified as C
 import Lang.Crucible.Backend.Online qualified as LCBO
 import Lang.Crucible.CFG.Core qualified as C

--- a/grease/src/Grease/Macaw/Overrides/SExp.hs
+++ b/grease/src/Grease/Macaw/Overrides/SExp.hs
@@ -8,16 +8,20 @@ module Grease.Macaw.Overrides.SExp (
   loadOverrides,
 ) where
 
+import Control.Exception.Safe (throw)
 import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Macaw.Symbolic.Syntax (machineCodeParserHooks)
 import Data.Proxy (Proxy (..))
 import Data.Sequence qualified as Seq
+import Data.Text qualified as Text
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Macaw.SimulatorState (MacawFnHandle, MacawOverride)
 import Grease.Syntax (parseProgram)
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.LLVM.Syntax (emptyParserHooks)
 import Lang.Crucible.Syntax.Concrete qualified as CSyn
 import Lang.Crucible.Syntax.Prog qualified as CSyn
+import Prettyprinter qualified as PP
 import Stubs.FunctionOverride qualified as Stubs
 import Stubs.Wrapper qualified as Stubs
 
@@ -59,6 +63,9 @@ loadOverride ::
   IO (Stubs.SomeFunctionOverride p sym arch)
 loadOverride path halloc = do
   let ?parserHooks = machineCodeParserHooks Proxy emptyParserHooks
-  prog <- parseProgram halloc path
-  CSyn.assertNoExterns (CSyn.parsedProgExterns prog)
-  Stubs.parsedProgToFunctionOverride path prog
+  progResult <- parseProgram halloc path
+  case progResult of
+    Left err -> throw $ GreaseException $ Text.pack $ show $ PP.pretty err
+    Right prog -> do
+      CSyn.assertNoExterns (CSyn.parsedProgExterns prog)
+      Stubs.parsedProgToFunctionOverride path prog

--- a/grease/src/Grease/Macaw/PLT.hs
+++ b/grease/src/Grease/Macaw/PLT.hs
@@ -29,6 +29,7 @@ import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Void (Void)
 import Data.Word (Word64)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Panic (panic)
 import Grease.Utility
 import Text.Megaparsec qualified as TM

--- a/grease/src/Grease/Main/Diagnostic.hs
+++ b/grease/src/Grease/Main/Diagnostic.hs
@@ -18,7 +18,7 @@ import Data.Parameterized.Context qualified as Ctx
 import Data.Sequence (Seq)
 import Data.Text qualified as Text
 import Data.Void (Void, absurd)
-import Grease.Diagnostic.Severity (Severity (Debug, Info, Warn))
+import Grease.Diagnostic.Severity (Severity (Debug, Error, Info, Warn))
 import Grease.Entrypoint (Entrypoint, EntrypointLocation)
 import Grease.Output (BatchStatus)
 import Grease.Requirement (Requirement, displayReq)
@@ -68,6 +68,8 @@ data Diagnostic where
     C.PrettyExt ext => C.CFG ext blocks args ret -> Diagnostic
   TypeContextError ::
     PP.Doc Void -> Diagnostic
+  UserError ::
+    PP.Doc Void -> Diagnostic
 
 instance PP.Pretty Diagnostic where
   pretty =
@@ -116,6 +118,7 @@ instance PP.Pretty Diagnostic where
             , C.ppCFG' True (C.postdomInfo cfg) cfg
             ]
       TypeContextError e -> fmap absurd e
+      UserError e -> "User error:" PP.<+> fmap absurd e
    where
     printCfg :: MM.AddrWidthRepr w -> ShapePP.PrinterConfig w
     printCfg w =
@@ -138,3 +141,4 @@ severity =
     SimulationGoalsFailed{} -> Info
     TargetCFG{} -> Debug
     TypeContextError{} -> Warn
+    UserError{} -> Error

--- a/grease/src/Grease/Main/Diagnostic.hs
+++ b/grease/src/Grease/Main/Diagnostic.hs
@@ -56,6 +56,9 @@ data Diagnostic where
     Diagnostic
   FinishedAnalyzingEntrypoint ::
     EntrypointLocation -> Nanoseconds -> Diagnostic
+  MalformedElf ::
+    PP.Doc Void ->
+    Diagnostic
   NoEntrypoints ::
     Diagnostic
   SimulationTestingRequirements ::
@@ -99,6 +102,8 @@ instance PP.Pretty Diagnostic where
           [ "Loaded precondition from path" PP.<+> PP.pretty path PP.<> ":"
           , ShapePP.evalPrinter (printCfg w) (ShapePP.printNamedShapes argNames argShapes)
           ]
+      MalformedElf err ->
+        "Malformed ELF file: " <> fmap absurd err
       NoEntrypoints ->
         "No entry points specified, analyzing all known functions."
       SimulationTestingRequirements rs ->
@@ -135,6 +140,7 @@ severity =
     BitcodeParseWarnings{} -> Warn
     FinishedAnalyzingEntrypoint{} -> Debug
     LoadedPrecondition{} -> Debug
+    MalformedElf{} -> Error
     NoEntrypoints -> Warn
     SimulationTestingRequirements{} -> Debug
     SimulationAllGoalsPassed{} -> Info

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -123,6 +123,7 @@ import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Cursor qualified as Cursor
 import Grease.Cursor.Pointer qualified as PtrCursor
 import Grease.Diagnostic
+import Grease.Error (GreaseException (GreaseException))
 import Grease.ExecutionFeatures (boundedExecFeats)
 import Grease.Heuristic
 import Grease.Options (BoundsOpts)

--- a/grease/src/Grease/Requirement.hs
+++ b/grease/src/Grease/Requirement.hs
@@ -15,7 +15,8 @@ import Data.Aeson qualified as Aeson
 import Data.Text (Text)
 import Data.Void (Void)
 import GHC.Generics (Generic)
-import Grease.Utility (GreaseException (GreaseException), tshow)
+import Grease.Error (GreaseException (GreaseException))
+import Grease.Utility (tshow)
 import Prettyprinter qualified as PP
 import Text.Megaparsec qualified as TM
 import Text.Megaparsec.Char qualified as TMC

--- a/grease/src/Grease/Shape.hs
+++ b/grease/src/Grease/Shape.hs
@@ -70,9 +70,9 @@ import Data.Text.Encoding qualified as Text
 import Data.Traversable qualified as Traversable
 import Data.Type.Equality (TestEquality (testEquality), (:~:) (Refl))
 import GHC.Show qualified as GShow
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Shape.NoTag (NoTag (NoTag))
 import Grease.Shape.Pointer (PtrShape, minimalPtrShape, parseJsonPtrShape, ptrShapeType, traversePtrShapeWithType)
-import Grease.Utility (GreaseException (..))
 import Lang.Crucible.CFG.Core qualified as C
 import Lang.Crucible.LLVM.Extension (LLVM)
 import Lang.Crucible.LLVM.MemModel (HasPtrWidth)

--- a/grease/src/Grease/Shape/Pointer.hs
+++ b/grease/src/Grease/Shape/Pointer.hs
@@ -73,8 +73,8 @@ import Data.Word (Word8)
 import GHC.TypeLits (type Natural, type (<=))
 import Grease.Cursor
 import Grease.Cursor.Pointer (Dereference (..))
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Shape.NoTag (NoTag (NoTag))
-import Grease.Utility
 import Lang.Crucible.CFG.Core qualified as C
 import Lang.Crucible.LLVM.Bytes (Bytes (..))
 import Lang.Crucible.LLVM.Bytes qualified as Bytes

--- a/grease/src/Grease/Syntax.hs
+++ b/grease/src/Grease/Syntax.hs
@@ -1,11 +1,17 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
 
 -- |
 -- Copyright        : (c) Galois, Inc. 2024
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Syntax (
+  -- * Error types
+  ParseProgramError (..),
+  ParseOverridesYamlError (..),
+  ResolveOverridesYamlError (..),
+
   -- * Parsing @.cbl@ files
   parseProgram,
   parsedProgramCfgMap,
@@ -17,8 +23,9 @@ module Grease.Syntax (
   ResolvedOverridesYaml (..),
 ) where
 
-import Control.Exception.Safe (throw)
 import Control.Monad (unless)
+import Control.Monad.IO.Class (liftIO)
+import Control.Monad.Trans.Except (ExceptT (..), runExceptT, throwE)
 import Data.Aeson qualified as Aeson
 import Data.Aeson.Key qualified as Key
 import Data.Aeson.KeyMap qualified as KeyMap
@@ -37,10 +44,9 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text.IO
+import Data.Void (Void)
 import Data.Word (Word64)
 import Data.Yaml qualified as Yaml
-import Grease.Error (GreaseException (GreaseException))
-import Grease.Utility (tshow)
 import Lang.Crucible.CFG.Extension qualified as C
 import Lang.Crucible.CFG.Reg qualified as C.Reg
 import Lang.Crucible.FunctionHandle qualified as C
@@ -48,9 +54,71 @@ import Lang.Crucible.Syntax.Atoms qualified as CSyn (atom)
 import Lang.Crucible.Syntax.Concrete qualified as CSyn
 import Lang.Crucible.Syntax.ExprParse qualified as CSyn
 import Lang.Crucible.Syntax.SExpr qualified as SExpr
+import Prettyprinter qualified as PP
 import Text.Megaparsec qualified as MP
 import Text.Read qualified as Read
 import What4.FunctionName qualified as W4
+
+-----
+-- Error types
+-----
+
+-- | Errors that can occur during program parsing
+--
+-- See the 'PP.Pretty' instance for details on each constructor.
+data ParseProgramError
+  = SExpressionParseError (MP.ParseErrorBundle Text.Text Void)
+  | SyntaxParseError Text.Text
+
+instance PP.Pretty ParseProgramError where
+  pretty =
+    \case
+      SExpressionParseError err -> PP.pretty (MP.errorBundlePretty err)
+      SyntaxParseError err -> PP.pretty err
+
+-- | Errors that can occur during YAML parsing
+--
+-- See the 'PP.Pretty' instance for details on each constructor.
+data ParseOverridesYamlError
+  = YamlParseError Yaml.ParseException
+  | UnexpectedYamlKeys [Text.Text]
+  | InvalidAddress Text.Text
+  | ExpectedString Text.Text
+  | ExpectedObject Text.Text
+  | ExpectedNullableObject Text.Text
+
+instance PP.Pretty ParseOverridesYamlError where
+  pretty =
+    \case
+      YamlParseError err ->
+        PP.pretty (Yaml.prettyPrintParseException err)
+      UnexpectedYamlKeys keys ->
+        PP.vsep $
+          "Unexpected keys in overrides.yaml file:"
+            : map (\key -> "- " <> PP.pretty key) keys
+      InvalidAddress addr ->
+        "Expected address in overrides YAML file, but encountered:" PP.<+> PP.pretty addr
+      ExpectedString val ->
+        "Expected string in overrides YAML file, but encountered:" PP.<+> PP.pretty val
+      ExpectedObject val ->
+        "Expected object in overrides YAML file, but encountered:" PP.<+> PP.pretty val
+      ExpectedNullableObject val ->
+        "Expected null or object in overrides YAML file, but encountered:" PP.<+> PP.pretty val
+
+-- | Errors that can occur during YAML resolution
+--
+-- See the 'PP.Pretty' instance for details on each constructor.
+data ResolveOverridesYamlError
+  = AddressUnresolvable Word64
+  | FunctionNameNotFound Text.Text
+
+instance PP.Pretty ResolveOverridesYamlError where
+  pretty =
+    \case
+      AddressUnresolvable addr ->
+        "Could not resolve" PP.<+> PP.pretty addr PP.<+> "to an address in the binary."
+      FunctionNameNotFound name ->
+        "Could not find an override for a function named:" PP.<+> PP.dquotes (PP.pretty name)
 
 -----
 -- Parsing .cbl files
@@ -63,17 +131,18 @@ parseProgram ::
   ) =>
   C.HandleAllocator ->
   FilePath ->
-  IO (CSyn.ParsedProgram ext)
-parseProgram halloc path = do
-  txt <- Text.IO.readFile path
+  IO (Either ParseProgramError (CSyn.ParsedProgram ext))
+parseProgram halloc path = runExceptT $ do
+  txt <- liftIO $ Text.IO.readFile path
   case MP.parse (SExpr.skipWhitespace *> MP.many (SExpr.sexp CSyn.atom) <* MP.eof) path txt of
-    Left err -> throw (GreaseException (Text.pack (MP.errorBundlePretty err)))
+    Left err -> throwE $ SExpressionParseError err
     Right v -> do
-      parseResult <- CSyn.top globalNonceGenerator halloc [] $ CSyn.prog v
+      parseResult <- liftIO $ CSyn.top globalNonceGenerator halloc [] $ CSyn.prog v
       case parseResult of
         Left (CSyn.SyntaxParseError e) ->
-          throw (GreaseException (CSyn.printSyntaxError e))
-        Left err -> throw (GreaseException (Text.pack (show err)))
+          throwE (SyntaxParseError (CSyn.printSyntaxError e))
+        Left err ->
+          throwE (SyntaxParseError (Text.pack (show err)))
         Right parsedProg -> pure parsedProg
 
 parsedProgramCfgMap ::
@@ -108,11 +177,11 @@ newtype ResolvedOverridesYaml w = ResolvedOverridesYaml
 -- | Parse an overrides-related @.yaml@ file.
 parseOverridesYaml ::
   FilePath ->
-  IO ParsedOverridesYaml
-parseOverridesYaml yamlPath = do
-  res <- Yaml.decodeFileEither yamlPath
+  IO (Either ParseOverridesYamlError ParsedOverridesYaml)
+parseOverridesYaml yamlPath = runExceptT $ do
+  res <- liftIO $ Yaml.decodeFileEither yamlPath
   case res of
-    Left ex -> throw $ GreaseException $ Text.pack $ Yaml.prettyPrintParseException ex
+    Left ex -> throwE $ YamlParseError ex
     Right val -> parseFunctionAddressOverrides val
 
 -- | Validate the contents of an overrides-related @.yaml@ file. See the
@@ -125,8 +194,8 @@ resolveOverridesYaml ::
   -- | The set of override names.
   Set W4.FunctionName ->
   ParsedOverridesYaml ->
-  IO (ResolvedOverridesYaml w)
-resolveOverridesYaml loadOpts mem fnOvNames (ParsedOverridesYaml parsedFunAddrs) = do
+  IO (Either ResolveOverridesYamlError (ResolvedOverridesYaml w))
+resolveOverridesYaml loadOpts mem fnOvNames (ParsedOverridesYaml parsedFunAddrs) = runExceptT $ do
   resolvedFunAddrs <-
     traverse
       ( \(addr, funName) -> do
@@ -135,17 +204,10 @@ resolveOverridesYaml loadOpts mem fnOvNames (ParsedOverridesYaml parsedFunAddrs)
             case Loader.resolveAbsoluteAddress mem addrWord of
               Just addrSegOff -> pure addrSegOff
               Nothing ->
-                throw $
-                  GreaseException $
-                    "Could not resolve "
-                      <> tshow addrWord
-                      <> "to an address in the binary."
+                throwE $ AddressUnresolvable (MM.memWordValue addrWord)
           unless (Set.member funName fnOvNames) $
-            throw $
-              GreaseException $
-                "Could not find an override for a function named '"
-                  <> W4.functionName funName
-                  <> "'."
+            throwE $
+              FunctionNameNotFound (W4.functionName funName)
           pure (addrSegOff, funName)
       )
       (Map.toList parsedFunAddrs)
@@ -160,7 +222,7 @@ resolveOverridesYaml loadOpts mem fnOvNames (ParsedOverridesYaml parsedFunAddrs)
 -- keys.
 parseFunctionAddressOverrides ::
   Aeson.Value ->
-  IO ParsedOverridesYaml
+  ExceptT ParseOverridesYamlError IO ParsedOverridesYaml
 parseFunctionAddressOverrides val = do
   mbObj <- asNullableObject val
   case mbObj of
@@ -168,13 +230,9 @@ parseFunctionAddressOverrides val = do
     Just obj -> do
       let objSansFunAddrOvs = KeyMap.delete funAddrOvsKey obj
       unless (KeyMap.null objSansFunAddrOvs) $
-        throw $
-          GreaseException $
-            Text.unlines $
-              "Unexpected keys in overrides.yaml file:"
-                : map
-                  (\key -> "- " <> Key.toText key)
-                  (KeyMap.keys objSansFunAddrOvs)
+        throwE $
+          UnexpectedYamlKeys $
+            map Key.toText (KeyMap.keys objSansFunAddrOvs)
       case KeyMap.lookup funAddrOvsKey obj of
         Nothing -> pure mempty
         Just funAddrOvs -> do
@@ -186,10 +244,7 @@ parseFunctionAddressOverrides val = do
                     case Read.readMaybe (Key.toString addrKey) of
                       Just addr -> pure addr
                       Nothing ->
-                        throw $
-                          GreaseException $
-                            "Expected address in overrides YAML file, but encountered "
-                              <> Key.toText addrKey
+                        throwE $ InvalidAddress (Key.toText addrKey)
                   funNameText <- asString funName
                   pure (addr, W4.functionNameFromText funNameText)
               )
@@ -203,25 +258,21 @@ parseFunctionAddressOverrides val = do
 --
 -- Assert that a JSON 'Aeson.Value' is a 'Aeson.String'. If this is the case,
 -- return the underlying text. Otherwise, throw an exception.
-asString :: Aeson.Value -> IO Text
+asString :: Aeson.Value -> ExceptT ParseOverridesYamlError IO Text
 asString (Aeson.String t) = pure t
 asString v =
-  throw $
-    GreaseException $
-      "Expected string in overrides YAML file, but encountered "
-        <> Text.decodeUtf8 (BS.toStrict (Aeson.encode v))
+  throwE $
+    ExpectedString (Text.decodeUtf8 (BS.toStrict (Aeson.encode v)))
 
 -- | Helper, not exported.
 --
 -- Assert that a JSON 'Aeson.Value' is an 'Aeson.Object'. If this is the case,
 -- return the underlying object. Otherwise, throw an exception.
-asObject :: Aeson.Value -> IO Aeson.Object
+asObject :: Aeson.Value -> ExceptT ParseOverridesYamlError IO Aeson.Object
 asObject (Aeson.Object o) = pure o
 asObject v =
-  throw $
-    GreaseException $
-      "Expected object in overrides YAML file, but encountered "
-        <> Text.decodeUtf8 (BS.toStrict (Aeson.encode v))
+  throwE $
+    ExpectedObject (Text.decodeUtf8 (BS.toStrict (Aeson.encode v)))
 
 -- | Helper, not exported.
 --
@@ -229,11 +280,9 @@ asObject v =
 -- is an 'Aeson.Object', return 'Just' the underlying object. If it is
 -- 'Aeson.Null', return 'Nothing'. If neither of these are the case, throw an
 -- exception.
-asNullableObject :: Aeson.Value -> IO (Maybe Aeson.Object)
+asNullableObject :: Aeson.Value -> ExceptT ParseOverridesYamlError IO (Maybe Aeson.Object)
 asNullableObject (Aeson.Object o) = pure $ Just o
 asNullableObject Aeson.Null = pure Nothing
 asNullableObject v =
-  throw $
-    GreaseException $
-      "Expected null or object in overrides YAML file, but encountered "
-        <> Text.decodeUtf8 (BS.toStrict (Aeson.encode v))
+  throwE $
+    ExpectedNullableObject (Text.decodeUtf8 (BS.toStrict (Aeson.encode v)))

--- a/grease/src/Grease/Syntax.hs
+++ b/grease/src/Grease/Syntax.hs
@@ -39,7 +39,8 @@ import Data.Text.Encoding qualified as Text
 import Data.Text.IO qualified as Text.IO
 import Data.Word (Word64)
 import Data.Yaml qualified as Yaml
-import Grease.Utility (GreaseException (..), tshow)
+import Grease.Error (GreaseException (GreaseException))
+import Grease.Utility (tshow)
 import Lang.Crucible.CFG.Extension qualified as C
 import Lang.Crucible.CFG.Reg qualified as C.Reg
 import Lang.Crucible.FunctionHandle qualified as C

--- a/grease/src/Grease/Utility.hs
+++ b/grease/src/Grease/Utility.hs
@@ -7,7 +7,6 @@
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Utility (
   OnlineSolverAndBackend,
-  GreaseException (..),
   pshow,
   tshow,
   functionNameFromByteString,
@@ -20,7 +19,7 @@ module Grease.Utility (
   bytes64LE,
 ) where
 
-import Control.Exception.Safe (Exception, MonadThrow)
+import Control.Exception.Safe (MonadThrow)
 import Control.Exception.Safe qualified as X
 import Data.ByteString qualified as BS
 import Data.ByteString.Builder qualified as Builder
@@ -31,6 +30,7 @@ import Data.Text (Text)
 import Data.Text qualified as Text
 import Data.Text.Encoding qualified as Text
 import Data.Word (Word32, Word64, Word8)
+import Grease.Error (GreaseException (GreaseException))
 import Grease.Panic (panic)
 import Lang.Crucible.Backend qualified as C
 import Lang.Crucible.Backend.Online qualified as C
@@ -50,11 +50,6 @@ type OnlineSolverAndBackend solver sym bak t st fs =
   , sym ~ W4.ExprBuilder t st fs
   , bak ~ C.OnlineBackend solver t st fs
   )
-
-newtype GreaseException = GreaseException Text
-instance Exception GreaseException
-instance Show GreaseException where
-  show (GreaseException msg) = Text.unpack msg
 
 pshow :: PP.Pretty a => a -> Text
 pshow = tshow . PP.pretty


### PR DESCRIPTION
Towards #4.

- Replace some `GreaseException`s with `panic`s
- Add some explicit error enumerations, categorize them (e.g., as user errors) in `Grease.Main`
- Create new, more specific types of exception