### PR TITLE
doc: Add `--diff-filter=d` to fourmolu pre-commit hook

### DIFF
--- a/doc/dev/dev.md
+++ b/doc/dev/dev.md
@@ -95,7 +95,7 @@ cat <<'EOF' > .git/hooks/pre-commit
 
 set -eu
 
-files=$(git diff --name-only --cached -- '*.hs')
+files=$(git diff --diff-filter=d --name-only --cached -- '*.hs')
 if [[ -n "${files}" ]]; then
     fourmolu --mode inplace ${files[@]}
     git add ${files[@]}


### PR DESCRIPTION
This avoids trying to format deleted files.

https://git-scm.com/docs/diff-options#Documentation/diff-options.txt---diff-filterACDMRTUXB

Fixes #412.