### PR TITLE
`grease-tests`: Remove stale TODO

### DIFF
--- a/grease-exe/tests/sanity/pass/thumb-calls/test.c
+++ b/grease-exe/tests/sanity/pass/thumb-calls/test.c
@@ -6,8 +6,6 @@ __attribute__((target("thumb"))) int callee(int *x) { return *x; }
 
 __attribute__((target("thumb"))) int test(int *x) { return callee(x); }
 
-// TODO(#432): The pop in callee should succeed but gives uninit stack
-
 // arm: flags {"--address", "0x1008b"}
 // arm: go(prog)
 


### PR DESCRIPTION
Issue #432 was fixed in #449, but due to an oversight, I forgot to remove a TODO(#432) line in #449. This corrects that oversight.