### PR TITLE
DWARF: Support arrays with constant upperbounds

### DIFF
--- a/grease/src/Grease/Macaw/Dwarf.hs
+++ b/grease/src/Grease/Macaw/Dwarf.hs
@@ -179,7 +179,6 @@ constructPtrTarget tyUnrollBound sprog visitCount tyApp =
   shapeSeq (MDwarf.SignedIntType w) = ishape w
   shapeSeq MDwarf.SignedCharType = ishape (1 :: Int)
   shapeSeq MDwarf.UnsignedCharType = ishape (1 :: Int)
-  -- TODO(#263): Need modification to DWARF to collect DW_TAG_count and properly evaluate dwarf ops for upper bounds in subranges
   shapeSeq (MDwarf.ArrayType elTy ub) =
     do
       let onlySubrange = if List.length ub == 1 then Maybe.listToMaybe ub else Nothing


### PR DESCRIPTION
This PR adds support for the old form of DWARF arrays in clang