### PR TITLE
doc: I/O overrides now available for LLVM, too

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -200,9 +200,6 @@ available:
 
 - `void @__stack_chk_fail()`
 - `void @__stack_chk_fail_local()`
-<!-- TODO(#387): Make these available for LLVM, too -->
-- `accept`, `bind`, `connect`, `listen`, `recv`, `send`, and `socket`: see
-  [I/O](io.md)>
 
 ### S-expression-specific overrides
 
@@ -238,6 +235,9 @@ also available:
 ### Discussion
 
 The following overrides merit a bit of discussion:
+
+- `accept`, `bind`, `connect`, `listen`, `recv`, `send`, and `socket`: see
+  [I/O](io.md)>
 
 - `abort`
 

--- a/doc/io.md
+++ b/doc/io.md
@@ -50,5 +50,3 @@ These overrides are quite limited.
 - Reading from sockets requires setting their contents in the symbolic
   filesystem in advance. (See GREASE's test suite for an example.)
 - `accept` ignores the `addr` and `addrlen` parameters.
-<!-- TODO(#387): Make these available for LLVM, too -->
-- These overrides are only available when analyzing binaries.


### PR DESCRIPTION
Fixes #560