### PR TITLE
cli: Add `--arg-str` and `--arg-sym-str` flags

### DIFF
--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -229,6 +229,18 @@ simpleShapesParser = fmap Map.fromList $ Opt.many $ do
             <> Opt.metavar "ARG:N"
             <> Opt.help "initialize argument ARG to an unsigned 64-bit integer"
         )
+    , Opt.option
+        (withArgName Simple.parseArgStr)
+        ( Opt.long "arg-str"
+            <> Opt.metavar "ARG:STRING"
+            <> Opt.help "initialize argument ARG to a pointer to a concrete, null-terminated, UTF-8 string"
+        )
+    , Opt.option
+        (withArgName Simple.parseArgSymStr)
+        ( Opt.long "arg-sym-str"
+            <> Opt.metavar "ARG:N"
+            <> Opt.help "initialize argument ARG to a pointer to a symbolic null-terminated string buffer of N bytes"
+        )
     ]
 
 addrOverridesParser :: Opt.Parser [(Integer, FilePath)]

--- a/grease-exe/tests/llvm/arg-str.llvm.cbl
+++ b/grease-exe/tests/llvm/arg-str.llvm.cbl
@@ -1,0 +1,15 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that the --arg-str CLI flag works for LLVM.
+
+(defun @test ((s (Ptr 64))) Unit
+  (start start:
+    (return ())))
+
+;; flags {"--symbol", "test"}
+;; flags {"--arg-str", "%0:hello"}
+;; go(prog)
+;; check "Using precondition:"
+;; check "%0: 000000+"
+;; check "000000: 68 65 6c 6c 6f 00"
+;; ok()

--- a/grease-exe/tests/llvm/arg-sym-str.llvm.cbl
+++ b/grease-exe/tests/llvm/arg-sym-str.llvm.cbl
@@ -1,0 +1,15 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that the --arg-sym-str CLI flag works for LLVM.
+
+(defun @test ((s (Ptr 64))) Unit
+  (start start:
+    (return ())))
+
+;; flags {"--symbol", "test"}
+;; flags {"--arg-sym-str", "%0:10"}
+;; go(prog)
+;; check "Using precondition:"
+;; check "%0: 000000+"
+;; check "000000: XX*9 00"
+;; ok()

--- a/grease-exe/tests/x86/arg-str.x64.cbl
+++ b/grease-exe/tests/x86/arg-str.x64.cbl
@@ -1,0 +1,15 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that the --arg-str CLI flag works for x64.
+
+(defun @test ((regs X86Regs)) X86Regs
+  (start start:
+    (return regs)))
+
+;; flags {"--symbol", "test"}
+;; flags {"--arg-str", "rdi:hello"}
+;; go(prog)
+;; check "Using precondition:"
+;; check "rdi: 000001+"
+;; check "000001: 68 65 6c 6c 6f 00"
+;; ok()

--- a/grease-exe/tests/x86/arg-sym-str.x64.cbl
+++ b/grease-exe/tests/x86/arg-sym-str.x64.cbl
@@ -1,0 +1,15 @@
+; Copyright (c) Galois, Inc. 2025
+
+; Ensure that the --arg-sym-str CLI flag works for x64.
+
+(defun @test ((regs X86Regs)) X86Regs
+  (start start:
+    (return regs)))
+
+;; flags {"--symbol", "test"}
+;; flags {"--arg-sym-str", "rdi:10"}
+;; go(prog)
+;; check "Using precondition:"
+;; check "rdi: 000001+"
+;; check "000001: XX*9 00"
+;; ok()

--- a/grease/src/Grease/Shape/Simple.hs
+++ b/grease/src/Grease/Shape/Simple.hs
@@ -16,6 +16,8 @@ module Grease.Shape.Simple (
   parseBufUninit,
   parseArgU32,
   parseArgU64,
+  parseArgStr,
+  parseArgSymStr,
   toShape,
   useSimpleShapes,
 ) where
@@ -24,6 +26,7 @@ import Control.Applicative (Alternative (empty), asum)
 import Control.Monad qualified as Monad
 import Data.BitVector.Sized (BV)
 import Data.BitVector.Sized qualified as BV
+import Data.ByteString qualified as BS
 import Data.Functor.Const qualified as Const
 import Data.Map.Strict (Map)
 import Data.Parameterized.Context qualified as Ctx
@@ -32,6 +35,7 @@ import Data.Parameterized.Some (Some (Some))
 import Data.Sequence qualified as Seq
 import Data.Text (Text)
 import Data.Text qualified as Text
+import Data.Text.Encoding qualified as Text
 import Data.Void (Void)
 import Data.Word (Word32, Word64)
 import Grease.Shape (Shape)
@@ -57,6 +61,10 @@ data SimpleShape
     ArgU32 !(BV 32)
   | -- | A 64-bit unsigned integer
     ArgU64 !(BV 64)
+  | -- | A pointer to a concrete null-terminated string
+    ArgStr !Text
+  | -- | A pointer to a symbolic null-terminated string buffer of @n@ bytes (including the null terminator)
+    ArgSymStr !Bytes
   deriving Show
 
 -- | Parse a symbol from 'TM.Tokens'.
@@ -106,6 +114,12 @@ parseArgU64 = ArgU64 <$> parseBV64
       fail ("Integer outside of 64-bit range: " ++ show i)
     pure (BV.mkBV (knownNat @64) i)
 
+parseArgStr :: TM.Parsec Void Text SimpleShape
+parseArgStr = ArgStr <$> TM.takeRest
+
+parseArgSymStr :: TM.Parsec Void Text SimpleShape
+parseArgSymStr = ArgSymStr <$> parseBytes
+
 toShape ::
   Shape.ExtShape ext 'PtrShape.Precond NoTag ~ PtrShape ext wptr 'PtrShape.Precond NoTag =>
   SimpleShape ->
@@ -122,6 +136,18 @@ toShape =
       Some (Shape.ShapeExt (PtrShape.ShapePtrBVLit NoTag (knownNat @32) bv))
     ArgU64 bv ->
       Some (Shape.ShapeExt (PtrShape.ShapePtrBVLit NoTag (knownNat @64) bv))
+    ArgStr str ->
+      -- A concrete null-terminated string
+      let bytes = BS.unpack (Text.encodeUtf8 str)
+          taggedBytes = fmap (\b -> PtrShape.TaggedByte NoTag b) (bytes ++ [0]) -- add null terminator
+          tgt = PtrShape.ptrTarget Nothing (Seq.singleton (PtrShape.Exactly taggedBytes))
+       in Some (Shape.ShapeExt (PtrShape.ShapePtr NoTag (PtrShape.PrecondPtrData (PtrShape.Offset 0) tgt)))
+    ArgSymStr n ->
+      -- A symbolic null-terminated string: n-1 symbolic bytes followed by a concrete null terminator
+      let symBytes = PtrShape.Initialized NoTag (n - 1)
+          nullByte = PtrShape.Exactly [PtrShape.TaggedByte NoTag 0]
+          tgt = PtrShape.ptrTarget Nothing (Seq.fromList [symBytes, nullByte])
+       in Some (Shape.ShapeExt (PtrShape.ShapePtr NoTag (PtrShape.PrecondPtrData (PtrShape.Offset 0) tgt)))
 
 -- | Override 'Shape.ArgShapes' using 'SimpleShape's (generally from the CLI)
 useSimpleShapes ::


### PR DESCRIPTION
Adds two new CLI flags for working with null-terminated strings:

- --arg-str ARG:STRING: Initializes argument ARG to a pointer to a concrete null-terminated string with the given content. For example, --arg-str rdi:hello creates a pointer to the bytes 'h','e','l','l','o',0.

- --arg-sym-str ARG:N: Initializes argument ARG to a pointer to a symbolic null-terminated string buffer of N bytes (including the null terminator). This is useful for testing string-handling code with symbolic inputs.

Closes #479