### PR TITLE
Shared discovery state

### DIFF
--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -52,6 +52,7 @@ import Data.Macaw.BinaryLoader (BinaryLoader)
 import Data.Macaw.BinaryLoader qualified as Loader
 import Data.Macaw.BinaryLoader.AArch32 ()
 import Data.Macaw.BinaryLoader.Raw ()
+import Data.IORef qualified as IORef
 import Data.Macaw.BinaryLoader.X86 ()
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Discovery qualified as Discovery
@@ -115,7 +116,7 @@ import Grease.Macaw.Arch.AArch32 (armCtx)
 import Grease.Macaw.Arch.PPC32 (ppc32Ctx)
 import Grease.Macaw.Arch.PPC64 (ppc64Ctx)
 import Grease.Macaw.Arch.X86 (x86Ctx)
-import Grease.Macaw.Discovery (discoverFunction)
+import Grease.Macaw.Discovery (discoverFunction, mkInitialDiscoveryState)
 import Grease.Macaw.Entrypoint (checkMacawEntrypointCfgsSignatures)
 import Grease.Macaw.Entrypoint qualified as GME
 import Grease.Macaw.Load qualified as Load
@@ -819,8 +820,13 @@ macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable e
   empTrace <- CR.emptyRecordedTrace sym
   repState <- CR.mkReplayState halloc empTrace
 
+  let discState0 = mkInitialDiscoveryState archCtx
+                      (mcMemory macawCfgConfig)
+                      (mcSymMap macawCfgConfig)
+                      (mcPltStubs macawCfgConfig)
+  discStateRef <- IORef.newIORef discState0
   let personality =
-        mkGreaseSimulatorState toConcVar dbgCtx recState repState
+        mkGreaseSimulatorState discStateRef toConcVar dbgCtx recState repState
           & discoveredFnHandles .~ discoveredHdls
 
   let globals = GSIO.initFsGlobals initFs

--- a/grease/src/Grease/Macaw/Discovery.hs
+++ b/grease/src/Grease/Macaw/Discovery.hs
@@ -3,11 +3,15 @@
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 module Grease.Macaw.Discovery (
   discoverFunction,
+  discoverFunctionWith,
+  discoverFunctionIncremental,
+  mkInitialDiscoveryState,
 ) where
 
 import Control.Lens (to, (.~), (^.))
 import Control.Monad.IO.Class (MonadIO (liftIO))
 import Data.Function ((&))
+import Data.IORef qualified as IORef
 import Data.Macaw.Architecture.Info qualified as MI
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Discovery qualified as Discovery
@@ -17,7 +21,7 @@ import Data.Macaw.Utils.IncComp qualified as IncComp
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Some (Some (Some))
 import Grease.Diagnostic (Diagnostic (LoadDiagnostic))
-import Grease.Macaw.Arch (ArchContext, ArchRegCFG)
+import Grease.Macaw.Arch (ArchContext, ArchRegCFG, archInfo, archVals)
 import Grease.Macaw.Arch qualified as Arch
 import Grease.Macaw.Load.Diagnostic qualified as Diag
 import Grease.Utility (functionNameFromByteString, tshow)
@@ -92,6 +96,74 @@ discoverFunction logAction halloc arch mem symMap pltStubs addr = do
         (functionNameFromByteString $ Discovery.discoveredFunName funInfo)
         (WPL.OtherPos . tshow) -- simply use addresses as source positions for now
         funInfo
+
+-- | Create the initial 'Discovery.DiscoveryState' for a binary, with PLT
+-- stubs marked as trusted function entry points. This state can be stored in
+-- an 'IORef' and shared across incremental discoveries via
+-- 'discoverFunctionIncremental'.
+mkInitialDiscoveryState ::
+  ArchContext arch ->
+  EL.Memory (MC.ArchAddrWidth arch) ->
+  Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
+  Map.Map (MC.ArchSegmentOff arch) WFN.FunctionName ->
+  Discovery.DiscoveryState arch
+mkInitialDiscoveryState arch mem symMap pltStubs =
+  let archInf = arch ^. archInfo
+      pltEntryPoints = Discovery.MayReturnFun <$ pltStubs
+  in Discovery.emptyDiscoveryState mem symMap archInf
+       & Discovery.trustedFunctionEntryPoints .~ pltEntryPoints
+
+-- | Discover a single function, returning the updated 'Discovery.DiscoveryState'.
+-- Each call benefits from knowledge accumulated by previous discoveries
+-- (e.g., known function boundaries). This maintains lazy, on-demand discovery
+-- while allowing the caller to thread state however it sees fit.
+discoverFunctionWith ::
+  MonadIO m =>
+  LJ.LogAction IO Diagnostic ->
+  C.HandleAllocator ->
+  ArchContext arch ->
+  Discovery.DiscoveryState arch ->
+  Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
+  MC.ArchSegmentOff arch ->
+  m (ArchRegCFG arch, Discovery.DiscoveryState arch)
+discoverFunctionWith logAction halloc arch s0 symMap addr = do
+  let archInf = arch ^. archInfo
+  MI.withArchConstraints archInf $ do
+    (s', Some funInfo) <-
+      IncComp.processIncCompLogs (logDiscoveryEvent logAction symMap) $ IncComp.runIncCompM $ do
+        IncComp.incCompLog $ Discovery.ReportAnalyzeFunction addr
+        let discoveryOpts = Discovery.defaultDiscoveryOptions
+        res@(_, Some funInfo) <-
+          IncComp.liftIncComp id $
+            Discovery.discoverFunction discoveryOpts addr Discovery.UserRequest s0 []
+        IncComp.incCompLog $ Discovery.ReportAnalyzeFunctionDone funInfo
+        pure res
+    cfg <- liftIO $
+      Symbolic.mkFunRegCFG
+        (arch ^. archVals . to Symbolic.archFunctions)
+        halloc
+        (functionNameFromByteString $ Discovery.discoveredFunName funInfo)
+        (WPL.OtherPos . tshow)
+        funInfo
+    pure (cfg, s')
+
+-- | Convenience wrapper around 'discoverFunctionWith' that reads and writes
+-- a shared 'Discovery.DiscoveryState' via an 'IORef'. Useful for IO callbacks
+-- (e.g., in distance computation) that cannot easily thread state.
+discoverFunctionIncremental ::
+  MonadIO m =>
+  LJ.LogAction IO Diagnostic ->
+  C.HandleAllocator ->
+  ArchContext arch ->
+  IORef.IORef (Discovery.DiscoveryState arch) ->
+  Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
+  MC.ArchSegmentOff arch ->
+  m (ArchRegCFG arch)
+discoverFunctionIncremental logAction halloc arch stateRef symMap addr = do
+  s <- liftIO $ IORef.readIORef stateRef
+  (cfg, s') <- discoverFunctionWith logAction halloc arch s symMap addr
+  liftIO $ IORef.writeIORef stateRef s'
+  pure cfg
 
 {-
 Note [Mark PLT stubs as trusted function entry points]

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -51,11 +51,11 @@ import Grease.Concretize.ToConcretize (HasToConcretize)
 import Grease.Diagnostic (Diagnostic (ResolveCallDiagnostic), GreaseLogAction)
 import Grease.Macaw.Arch (ArchContext)
 import Grease.Macaw.Arch qualified as Arch
-import Grease.Macaw.Discovery (discoverFunction)
+import Grease.Macaw.Discovery (discoverFunctionIncremental)
 import Grease.Macaw.Overrides (lookupMacawForwardDeclarationOverride)
 import Grease.Macaw.Overrides.SExp (MacawSExpOverride (MacawSExpOverride, msoPublicFnHandle, msoPublicOverride, msoSomeFunctionOverride))
 import Grease.Macaw.ResolveCall.Diagnostic qualified as Diag
-import Grease.Macaw.SimulatorState (HasGreaseSimulatorState, MacawFnHandle, MacawOverride, stateDiscoveredFnHandles, stateSyscallHandles)
+import Grease.Macaw.SimulatorState (HasGreaseSimulatorState, MacawFnHandle, MacawOverride, discoveryStateRef, greaseSimulatorState, stateDiscoveredFnHandles, stateSyscallHandles)
 import Grease.Macaw.SkippedCall (
   SkippedFunctionCall (
     InvalidAddress,
@@ -405,7 +405,7 @@ lookupFunctionHandleResult bak la halloc arch memory symMap pltStubs dynFunMap f
     | Discovery.isExecutableSegOff funcAddrOff = do
         fixedAddr <- (arch ^. Arch.archPCFixup) bak regs funcAddrOff
         (hdl, st') <-
-          discoverFuncAddr la halloc arch memory symMap pltStubs fixedAddr st
+          discoverFuncAddr la halloc arch symMap fixedAddr st
         let nm = C.handleName hdl
         maybeUserSkip nm $
           pure
@@ -600,7 +600,9 @@ lookupSyscallHandle bak arch syscallOvs errorSymbolicSyscalls lsd =
 
 -- | Perform code discovery on the function address (see @Note [Incremental
 -- code discovery]@ in "Grease.Macaw.SimulatorState") and bind the function
--- handle to its CFG.
+-- handle to its CFG. Uses the shared 'Discovery.DiscoveryState' stored in the
+-- 'GreaseSimulatorState' so that each successive discovery benefits from
+-- knowledge accumulated by previous ones.
 discoverFuncAddr ::
   ( Symbolic.SymArchConstraints arch
   , HasGreaseSimulatorState p cExt sym arch ret
@@ -608,11 +610,8 @@ discoverFuncAddr ::
   LJ.LogAction IO Diagnostic ->
   C.HandleAllocator ->
   ArchContext arch ->
-  EL.Memory (MC.ArchAddrWidth arch) ->
   -- | Map of entrypoint addresses to their names
   Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
-  -- | Map of addresses to PLT stub names
-  Map.Map (MC.ArchSegmentOff arch) WFN.FunctionName ->
   -- | The function address
   MC.ArchSegmentOff arch ->
   -- | The current Crucible state
@@ -621,9 +620,10 @@ discoverFuncAddr ::
     ( MacawFnHandle arch
     , CS.SimState p sym (Symbolic.MacawExt arch) r f a
     )
-discoverFuncAddr logAction halloc arch memory symMap pltStubs addr st0 = do
+discoverFuncAddr logAction halloc arch symMap addr st0 = do
+  let stateRef = st0 ^. CS.stateContext . CS.cruciblePersonality . greaseSimulatorState . discoveryStateRef
   C.Reg.SomeCFG regCFG <-
-    discoverFunction logAction halloc arch memory symMap pltStubs addr
+    discoverFunctionIncremental logAction halloc arch stateRef symMap addr
   C.SomeCFG funcCFG <- pure (C.toSSA regCFG)
   let cfgHdl = C.cfgHandle funcCFG
   let st1 = st0 & stateDiscoveredFnHandles %~ Map.insert addr cfgHdl

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -11,9 +11,11 @@ module Grease.Macaw.SimulatorState (
   GreaseSimulatorState (..),
   mkGreaseSimulatorState,
   HasGreaseSimulatorState (..),
+  HasDiscoveryState (..),
 
   -- * Lenses for @GreaseSimulatorState@
   discoveredFnHandles,
+  discoveryStateRef,
   syscallHandles,
   macawLazySimulatorState,
   gssRecordState,
@@ -31,8 +33,10 @@ module Grease.Macaw.SimulatorState (
 import Control.Lens (Lens')
 import Control.Lens qualified as Lens
 import Control.Lens.TH (makeLenses)
+import Data.IORef (IORef)
 import Data.Kind (Type)
 import Data.Macaw.CFG qualified as MC
+import Data.Macaw.Discovery qualified as Discovery
 import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Context qualified as Ctx
@@ -59,7 +63,12 @@ type GreaseSimulatorState ::
   CT.CrucibleType ->
   Type
 data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
-  { _discoveredFnHandles :: Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch)
+  { _discoveryStateRef :: IORef (Discovery.DiscoveryState arch)
+  -- ^ A shared, mutable 'Discovery.DiscoveryState' used for incremental code
+  -- discovery. Each call to 'Grease.Macaw.Discovery.discoverFunctionIncremental'
+  -- reads and updates this state, so successive discoveries benefit from
+  -- knowledge accumulated by previous ones (e.g., known function boundaries).
+  , _discoveredFnHandles :: Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch)
   -- ^ A map of discovered function addresses to their handles. Any time a new
   -- function is discovered (see @Note [Incremental code discovery]@), it will
   -- be added to this map so that it can be looked up in future invocations of
@@ -116,14 +125,16 @@ data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
 mkGreaseSimulatorState ::
   forall cExt sym arch ret p.
   (p ~ GreaseSimulatorState cExt sym arch ret) =>
+  IORef (Discovery.DiscoveryState arch) ->
   CS.GlobalVar ToConc.ToConcretizeType ->
   Dbg.Context cExt sym (Symbolic.MacawExt arch) ret ->
   CR.RecordState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   CR.ReplayState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   p
-mkGreaseSimulatorState toConcVar dbgCtx recState repState =
+mkGreaseSimulatorState discStateRef toConcVar dbgCtx recState repState =
   GreaseSimulatorState
-    { _discoveredFnHandles = Map.empty
+    { _discoveryStateRef = discStateRef
+    , _discoveredFnHandles = Map.empty
     , _toConcretize = toConcVar
     , _syscallHandles = MapF.empty
     , _macawLazySimulatorState = Symbolic.emptyMacawLazySimulatorState
@@ -146,6 +157,17 @@ class
     | p -> cExt sym arch ret
   where
   greaseSimulatorState :: Lens' p (GreaseSimulatorState cExt sym arch ret)
+
+-- | A class for personality types that provide access to a shared, mutable
+-- 'Discovery.DiscoveryState'. This enables incremental code discovery where
+-- each successive function discovery benefits from knowledge accumulated by
+-- previous ones.
+--
+-- The 'IORef' is intentional: when the scheduler snapshots a 'SimState' into
+-- a 'WorkItem', the 'IORef' ensures that all suspended paths share the same
+-- discovery knowledge, avoiding redundant rediscovery.
+class HasDiscoveryState p arch | p -> arch where
+  getDiscoveryStateRef :: p -> IORef (Discovery.DiscoveryState arch)
 
 -----
 -- These types should probably be defined in Grease.Macaw.FunctionOverride, but
@@ -202,6 +224,9 @@ instance
     ret
   where
   greaseSimulatorState = id
+
+instance HasDiscoveryState (GreaseSimulatorState cExt sym arch ret) arch where
+  getDiscoveryStateRef = Lens.view discoveryStateRef
 
 instance GSN.HasServerSocketFds (GreaseSimulatorState cExt sym arch ret) where
   serverSocketFdsL = serverSocketFds

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -841,6 +841,7 @@ withPrioritizationFunction ::
   ResolvedTargetLoc 64 ->
   ( ( forall p sym rtp.
       ( SDSE.HasDistancesState p
+      , GMSS.HasDiscoveryState p MX86.X86_64
       , RR.HasRecordState p p sym ext rtp
       , RR.HasReplayState p p sym ext rtp
       , WI.IsExprBuilder sym
@@ -868,6 +869,7 @@ withPrioritizationFunction conf avoidList archCtx cfgCache sla gla elf halloc re
           MM.MemWord 64 ->
           forall p sym ext rtp.
           ( SDSE.HasDistancesState p
+          , GMSS.HasDiscoveryState p MX86.X86_64
           , RR.HasRecordState p p sym ext rtp
           , RR.HasReplayState p p sym ext rtp
           , WI.IsExprBuilder sym
@@ -893,6 +895,7 @@ withPrioritizationFunction conf avoidList archCtx cfgCache sla gla elf halloc re
         cgPfunc ::
           forall p sym ext rtp.
           ( SDSE.HasDistancesState p
+          , GMSS.HasDiscoveryState p MX86.X86_64
           , RR.HasRecordState p p sym ext rtp
           , RR.HasReplayState p p sym ext rtp
           , WI.IsExprBuilder sym
@@ -1099,7 +1102,7 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
                 (overrideError sla)
         let lfhd
               | isEcfs =
-                  ecfsLookupFunctionHandleDispatch gla halloc archCtx mem symMap pltStubs defaultLfhd
+                  ecfsLookupFunctionHandleDispatch gla halloc archCtx symMap defaultLfhd
               | otherwise =
                   defaultLfhd
         let memCfg =
@@ -1187,8 +1190,10 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
         gssRecState <- RR.mkRecordState halloc
         gssEmpTrace <- RR.emptyRecordedTrace sym
         gssRepState <- RR.mkReplayState halloc gssEmpTrace
+        let discState0 = GMD.mkInitialDiscoveryState archCtx mem symMap pltStubs
+        discStateRef <- IORef.newIORef discState0
         let greaseSimState =
-              GMSS.mkGreaseSimulatorState toConcVar dbgCtx gssRecState gssRepState
+              GMSS.mkGreaseSimulatorState discStateRef toConcVar dbgCtx gssRecState gssRepState
                 & GMSS.discoveredFnHandles .~ discoveredHdls
         personality <-
           SP.mkScreachSimulatorState
@@ -1439,6 +1444,7 @@ analyzeCfg ::
   GE.EntrypointCfgs (CCR.SomeCFG ext args ret) ->
   ( forall p sym rtp.
     ( SDSE.HasDistancesState p
+    , GMSS.HasDiscoveryState p MX86.X86_64
     , RR.HasRecordState p p sym ext rtp
     , RR.HasReplayState p p sym ext rtp
     , WI.IsExprBuilder sym

--- a/screach/src/Screach/CallGraph.hs
+++ b/screach/src/Screach/CallGraph.hs
@@ -168,6 +168,7 @@ getCFG ::
   , Symbolic.SymArchConstraints arch
   ) =>
   CFGCache w ->
+  IORef.IORef (MD.DiscoveryState arch) ->
   MM.Memory w ->
   MM.MemWord w ->
   ScreachLogAction ->
@@ -175,16 +176,15 @@ getCFG ::
   CFH.HandleAllocator ->
   Arch.ArchContext arch ->
   MD.AddrSymMap (MC.ArchAddrWidth arch) ->
-  Map.Map (MC.ArchSegmentOff arch) WFN.FunctionName ->
   IO (Maybe (Some.Some CCC.AnyCFG))
-getCFG (CFGCache cfgCache) mem addr sla gla halloc archCtx symMap pltStubs =
+getCFG (CFGCache cfgCache) discoveryStateRef mem addr sla gla halloc archCtx symMap =
   case MM.resolveAbsoluteAddr mem addr of
     Just segOff -> do
       cache <- IORef.readIORef cfgCache
       case Map.lookup segOff cache of
         Just cfg -> pure $ Just cfg
         Nothing -> do
-          CCR.SomeCFG cfgReg <- GMD.discoverFunction gla halloc archCtx mem symMap pltStubs segOff
+          CCR.SomeCFG cfgReg <- GMD.discoverFunctionIncremental gla halloc archCtx discoveryStateRef symMap segOff
           LJ.writeLog sla (ScrchDiag.DistanceDiagnostic $ Diagnositc.DiscoveredCFG addr (CCR.SomeCFG cfgReg))
           let cfg' = case CCS.toSSA cfgReg of
                 CCC.SomeCFG cfg -> Some.Some $ CCC.AnyCFG cfg
@@ -235,17 +235,17 @@ resolveCall ::
   ) =>
   CallGraph w ->
   CFGCache w ->
+  IORef.IORef (MD.DiscoveryState arch) ->
   ScreachLogAction ->
   GreaseLogAction ->
   MM.Memory w ->
   CFH.HandleAllocator ->
   Arch.ArchContext arch ->
   MD.AddrSymMap (MC.ArchAddrWidth arch) ->
-  Map.Map (MC.ArchSegmentOff arch) WFN.FunctionName ->
   WPL.ProgramLoc ->
   WPL.ProgramLoc ->
   IO [Some.Some CCC.AnyCFG]
-resolveCall callGraph cfgCaches sla gla mem hLoc archContext symMap pltStubs callerLoc callsiteLoc = do
+resolveCall callGraph cfgCaches discoveryStateRef sla gla mem hLoc archContext symMap callerLoc callsiteLoc = do
   let mbCaller = locToAddressMaybe callerLoc
   let mbCallsite = locToAddressMaybe callsiteLoc
   case (mbCaller, mbCallsite) of
@@ -273,4 +273,4 @@ resolveCall callGraph cfgCaches sla gla mem hLoc archContext symMap pltStubs cal
       pure []
  where
   getCFGFromAddr :: MM.MemWord w -> IO (Maybe (Some.Some CCC.AnyCFG))
-  getCFGFromAddr addr = getCFG cfgCaches mem addr sla gla hLoc archContext symMap pltStubs
+  getCFGFromAddr addr = getCFG cfgCaches discoveryStateRef mem addr sla gla hLoc archContext symMap

--- a/screach/src/Screach/Personality.hs
+++ b/screach/src/Screach/Personality.hs
@@ -20,6 +20,7 @@ import Data.IORef qualified as IORef
 import Data.Kind (Type)
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Symbolic qualified as MS
+import Data.Macaw.X86 qualified as MA
 import Data.Macaw.Symbolic.Debug qualified as MDebug
 import Data.Parameterized.Ctx qualified as C
 import GHC.TypeLits (type Natural)
@@ -61,6 +62,9 @@ makeLenses ''ScreachSimulatorState
 
 instance ShortDistSched.HasDistancesState (ScreachSimulatorState p sym bak ext arch t ret aty w) where
   distancesRef = _distState
+
+instance (arch ~ MA.X86_64) => GMSS.HasDiscoveryState (ScreachSimulatorState p sym bak ext arch t ret aty w) arch where
+  getDiscoveryStateRef sss = Lens.view (greaseSimulatorState . GMSS.discoveryStateRef) sss
 
 instance
   ( ext ~ MS.MacawExt arch

--- a/screach/src/Screach/ResolveCall.hs
+++ b/screach/src/Screach/ResolveCall.hs
@@ -5,14 +5,12 @@ module Screach.ResolveCall (
 import Data.Macaw.CFG qualified as MC
 import Data.Macaw.Discovery qualified as Discovery
 import Data.Macaw.Symbolic qualified as Symbolic
-import Data.Map.Strict qualified as Map
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.Macaw.Arch (ArchContext)
 import Grease.Macaw.ResolveCall qualified as ResolveCall
 import Grease.Macaw.SimulatorState
 import Grease.Macaw.SkippedCall qualified as SkippedCall
 import Lang.Crucible.FunctionHandle qualified as CFH
-import What4.FunctionName qualified as WFN
 
 -- | A 'ResolveCall.LookupFunctionHandleDispatch' specifically geared towards
 -- ECFS files. ECFS files include shared libraries in a giant address space, so
@@ -28,19 +26,17 @@ ecfsLookupFunctionHandleDispatch ::
   GreaseLogAction ->
   CFH.HandleAllocator ->
   ArchContext arch ->
-  MC.Memory (MC.ArchAddrWidth arch) ->
   Discovery.AddrSymMap (MC.ArchAddrWidth arch) ->
-  Map.Map (MC.ArchSegmentOff arch) WFN.FunctionName ->
   ResolveCall.LookupFunctionHandleDispatch p sym arch ->
   ResolveCall.LookupFunctionHandleDispatch p sym arch
-ecfsLookupFunctionHandleDispatch la halloc arch memory symMap pltStubs lfhd =
+ecfsLookupFunctionHandleDispatch la halloc arch symMap lfhd =
   let ResolveCall.LookupFunctionHandleDispatch defaultDispatch = lfhd
    in ResolveCall.LookupFunctionHandleDispatch $ \st mem regs lfhr -> do
         let dispatch' st' = defaultDispatch st' mem regs
         case lfhr of
           ResolveCall.SkippedFunctionCall (SkippedCall.PltNoOverride pltAddr _pltName) -> do
             (hdl, st') <-
-              ResolveCall.discoverFuncAddr la halloc arch memory symMap pltStubs pltAddr st
+              ResolveCall.discoverFuncAddr la halloc arch symMap pltAddr st
             dispatch' st' $
               ResolveCall.DiscoveredFnHandle pltAddr hdl Nothing
           _ -> dispatch' st lfhr

--- a/screach/src/Screach/ShortestDistanceScheduler.hs
+++ b/screach/src/Screach/ShortestDistanceScheduler.hs
@@ -24,7 +24,8 @@ import Data.Maybe qualified as Maybe
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Some qualified as Some
 import Grease.Diagnostic (GreaseLogAction)
-import Grease.Macaw.Arch qualified as Arch
+import Grease.Macaw.Arch qualified as GRS
+import Grease.Macaw.SimulatorState qualified as GMSS
 import Grease.Scheduler qualified as Sched
 import Lang.Crucible.CFG.Core qualified as CCC
 import Lang.Crucible.FunctionHandle qualified as CFH
@@ -172,6 +173,7 @@ runWithCachesRef ref action = do
 sdsePrioritizationFunction ::
   forall p sym ext rtp.
   ( HasDistancesState p
+  , GMSS.HasDiscoveryState p MA.X86_64
   , RR.HasRecordState p p sym ext rtp
   , RR.HasReplayState p p sym ext rtp
   , WI.IsExprBuilder sym
@@ -180,7 +182,7 @@ sdsePrioritizationFunction ::
   MM.MemWord 64 ->
   -- | Target containing function
   MM.MemWord 64 ->
-  Arch.ArchContext MA.X86_64 ->
+  GRS.ArchContext MA.X86_64 ->
   CG.CallGraph 64 ->
   CG.CFGCache 64 ->
   Dist.DistanceConfig ->
@@ -193,14 +195,15 @@ sdsePrioritizationFunction tgtAddr tgtFunction archCtx cg cache distConfig sla g
   let LoadedELF
         { symMap = symMap
         , mem = mem
-        , pltStubs = pltStubs
         } = lElf
-      cachesRef = distancesRef (state ^. C.stateContext . C.cruciblePersonality)
+      personality = state ^. C.stateContext . C.cruciblePersonality
+      cachesRef = distancesRef personality
+      discStateRef = GMSS.getDiscoveryStateRef personality
       maybeRes :: MaybeT (Dist.DistanceMonad Dist.DijkstraCaches) Dist.Distance
       maybeRes =
         do
           (cfg, snode) <- MaybeT $ liftIO $ getExplorationEntry state frame
-          let rcall (Dist.FunctionEntry fentry) (Dist.Callsite callsite) = CG.resolveCall cg cache sla gla mem halloc archCtx symMap pltStubs fentry callsite
+          let rcall (Dist.FunctionEntry fentry) (Dist.Callsite callsite) = CG.resolveCall cg cache discStateRef sla gla mem halloc archCtx symMap fentry callsite
           Dist.CallStack cs <- MaybeT $ lift $ Just <$> callStackFromSimState state
           let poppedCS = Maybe.fromMaybe [] $ tailMay cs
           let
@@ -217,7 +220,7 @@ sdsePrioritizationFunction tgtAddr tgtFunction archCtx cg cache distConfig sla g
                         Nothing -> do
                           LJ.writeLog sla (ScrchDiagnostic.AttemptedToReturnViaCallgraphForNonAddressFunction floc)
                           pure Nothing
-                        Just a -> CG.getCFG cache mem a sla gla halloc archCtx symMap pltStubs
+                        Just a -> CG.getCFG cache discStateRef mem a sla gla halloc archCtx symMap
                 )
           let retHandler =
                 Dist.ReturnHandler


### PR DESCRIPTION
Stash `DiscoveryState` in a shared `IORef` in the personality, reuse and update it instead of making new ones. To be honest, this isn't that big of an improvement in performance nor accuracy: for most binaries, we have the PLT stubs as trusted entry points. Even for stripped binaries we do incremental discovery, meaning we already trust the address being called as an entrypoint. That being said, there's no harm in reusing it and it's the same number of parameters as passing around the PLT stubs. It could probably help in obscure situations involving stripped binaries. And finally, it does remove *some* amount of unnecessary allocations when creating a new `DiscoveryState`.