### PR TITLE
Common type for shared personality fields

### DIFF
--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -136,6 +136,7 @@ import Grease.MustFail qualified as MustFail
 import Grease.Options qualified as GO
 import Grease.Output qualified as GOut
 import Grease.Panic (Grease, panic)
+import Grease.Personality qualified as GP
 import Grease.Pretty (prettyPtrFnMap)
 import Grease.Profiler.Feature (greaseProfilerFeature)
 import Grease.Refine qualified as GRef
@@ -812,8 +813,14 @@ macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable e
   empTrace <- CR.emptyRecordedTrace sym
   repState <- CR.mkReplayState halloc empTrace
 
+  let pers =
+        GP.Personality
+          { GP._pDbgContext = dbgCtx
+          , GP._pToConcretize = toConcVar
+          , GP._pServerSocketFds = Map.empty
+          }
   let personality =
-        mkGreaseSimulatorState toConcVar dbgCtx recState repState
+        mkGreaseSimulatorState pers recState repState
           & discoveredFnHandles .~ discoveredHdls
 
   let globals = GSIO.initFsGlobals initFs
@@ -1450,8 +1457,14 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
         heuristics
         execFeats
         $ \toConc setupMem initFs args -> do
+          let llvmPers =
+                GP.Personality
+                  { GP._pDbgContext = dbgCtx
+                  , GP._pToConcretize = toConc
+                  , GP._pServerSocketFds = Map.empty
+                  }
           let p =
-                GLP.mkGreaseLLVMPersonality dbgCtx toConc recState repState
+                GLP.mkGreaseLLVMPersonality llvmPers recState repState
           LLVM.initState
             bak
             la

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -255,6 +255,7 @@ library
     Grease.Output
     Grease.Overrides.Networking
     Grease.Panic
+    Grease.Personality
     Grease.Pretty
     Grease.Refine
     Grease.Refine.Diagnostic

--- a/grease/src/Grease/LLVM/Personality.hs
+++ b/grease/src/Grease/LLVM/Personality.hs
@@ -12,9 +12,7 @@ module Grease.LLVM.Personality (
   HasGreaseLLVMPersonality (..),
 
   -- * Lenses for @GreaseLLVMPersonality@
-  llvmDbgContext,
-  llvmToConcretize,
-  llvmServerSocketFds,
+  llvmPersonality,
   llvmRecordState,
   llvmReplayState,
 ) where
@@ -23,9 +21,8 @@ import Control.Lens (Lens')
 import Control.Lens qualified as Lens
 import Control.Lens.TH (makeLenses)
 import Data.Kind (Type)
-import Data.Map.Strict qualified as Map
-import Data.Parameterized.Some (Some)
 import Grease.Concretize.ToConcretize qualified as ToConc
+import Grease.Personality qualified as GP
 import Grease.SimulatorState.Networking qualified as GSN
 import Lang.Crucible.Debug qualified as Dbg
 import Lang.Crucible.LLVM (LLVM)
@@ -44,14 +41,8 @@ type GreaseLLVMPersonality ::
   Type
 data GreaseLLVMPersonality cExt sym ret
   = GreaseLLVMPersonality
-  { _llvmDbgContext :: Dbg.Context cExt sym LLVM ret
-  , _llvmToConcretize :: CS.GlobalVar ToConc.ToConcretizeType
-  -- ^ Values created during runtime to be passed to the concretization
-  -- functionality and generally displayed to the user.
-  , _llvmServerSocketFds :: Map.Map Integer (Some GSN.ServerSocketInfo)
-  -- ^ A map from registered socket file descriptors to their corresponding
-  -- metadata. See @Note [The networking story]@ in
-  -- "Grease.Overrides.Networking".
+  { _llvmPersonality :: GP.Personality cExt sym LLVM ret
+  -- ^ The shared personality core. See 'Grease.Personality.Personality'.
   , _llvmRecordState ::
       CR.RecordState
         (GreaseLLVMPersonality cExt sym ret)
@@ -72,16 +63,13 @@ makeLenses ''GreaseLLVMPersonality
 mkGreaseLLVMPersonality ::
   forall cExt sym ret p.
   (p ~ GreaseLLVMPersonality cExt sym ret) =>
-  Dbg.Context cExt sym LLVM ret ->
-  CS.GlobalVar ToConc.ToConcretizeType ->
+  GP.Personality cExt sym LLVM ret ->
   CR.RecordState p sym LLVM (CS.RegEntry sym ret) ->
   CR.ReplayState p sym LLVM (CS.RegEntry sym ret) ->
   p
-mkGreaseLLVMPersonality dbgCtx toConcVar recState repState =
+mkGreaseLLVMPersonality pers recState repState =
   GreaseLLVMPersonality
-    { _llvmDbgContext = dbgCtx
-    , _llvmToConcretize = toConcVar
-    , _llvmServerSocketFds = Map.empty
+    { _llvmPersonality = pers
     , _llvmRecordState = recState
     , _llvmReplayState = repState
     }
@@ -97,14 +85,18 @@ instance HasGreaseLLVMPersonality (GreaseLLVMPersonality cExt sym ret) cExt sym 
   {-# INLINE greaseLlvmPersonality #-}
 
 instance Dbg.HasContext (GreaseLLVMPersonality cExt sym ret) cExt sym LLVM ret where
-  context = llvmDbgContext
+  context = llvmPersonality . GP.pDbgContext
   {-# INLINE context #-}
 
 instance ToConc.HasToConcretize (GreaseLLVMPersonality cExt sym ret) where
-  toConcretize = Lens.view llvmToConcretize
+  toConcretize = Lens.view (llvmPersonality . GP.pToConcretize)
 
 instance GSN.HasServerSocketFds (GreaseLLVMPersonality cExt sym ret) where
-  serverSocketFdsL = llvmServerSocketFds
+  serverSocketFdsL = llvmPersonality . GP.pServerSocketFds
+
+instance GP.HasPersonality (GreaseLLVMPersonality cExt sym ret) cExt sym LLVM ret where
+  personality = llvmPersonality
+  {-# INLINE personality #-}
 
 instance
   CR.HasRecordState

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -13,6 +13,7 @@ module Grease.Macaw.SimulatorState (
   HasGreaseSimulatorState (..),
 
   -- * Lenses for @GreaseSimulatorState@
+  gssPersonality,
   discoveredFnHandles,
   syscallHandles,
   macawLazySimulatorState,
@@ -21,7 +22,6 @@ module Grease.Macaw.SimulatorState (
   stateDiscoveredFnHandles,
   stateSyscallHandles,
   stateMacawLazySimulatorState,
-  serverSocketFds,
 
   -- * Auxiliary definitions
   MacawFnHandle,
@@ -37,8 +37,8 @@ import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Map qualified as MapF
-import Data.Parameterized.Some (Some)
 import Grease.Concretize.ToConcretize qualified as ToConc
+import Grease.Personality qualified as GP
 import Grease.SimulatorState.Networking qualified as GSN
 import Lang.Crucible.Debug qualified as Dbg
 import Lang.Crucible.FunctionHandle qualified as C
@@ -59,14 +59,13 @@ type GreaseSimulatorState ::
   CT.CrucibleType ->
   Type
 data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
-  { _discoveredFnHandles :: Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch)
+  { _gssPersonality :: GP.Personality cExt sym (Symbolic.MacawExt arch) ret
+  -- ^ The shared personality core. See 'Grease.Personality.Personality'.
+  , _discoveredFnHandles :: Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch)
   -- ^ A map of discovered function addresses to their handles. Any time a new
   -- function is discovered (see @Note [Incremental code discovery]@), it will
   -- be added to this map so that it can be looked up in future invocations of
   -- that function.
-  , _toConcretize :: CS.GlobalVar ToConc.ToConcretizeType
-  -- ^ Values created during runtime to be passed to the concretization
-  -- functionality and generally displayed to the user.
   , _syscallHandles :: MapF.MapF Stubs.SyscallNumRepr Stubs.SyscallFnHandle
   -- ^ A map of syscall numbers (that have been invoked thus far during
   -- simulation) to their handles. Any time a new syscall is simulated, it
@@ -93,11 +92,6 @@ data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
   , _macawLazySimulatorState :: Symbolic.MacawLazySimulatorState sym (MC.ArchAddrWidth arch)
   -- ^ The state used in the lazy @macaw-symbolic@ memory model, on top of
   -- which @grease@ is built.
-  , _serverSocketFds :: Map.Map Integer (Some GSN.ServerSocketInfo)
-  -- ^ A map from registered socket file descriptors to their corresponding
-  -- metadata. See @Note [The networking story]@ in
-  -- "Grease.Overrides.Networking".
-  , _dbgContext :: Dbg.Context cExt sym (Symbolic.MacawExt arch) ret
   , _gssRecordState ::
       CR.RecordState
         (GreaseSimulatorState cExt sym arch ret)
@@ -116,19 +110,16 @@ data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
 mkGreaseSimulatorState ::
   forall cExt sym arch ret p.
   (p ~ GreaseSimulatorState cExt sym arch ret) =>
-  CS.GlobalVar ToConc.ToConcretizeType ->
-  Dbg.Context cExt sym (Symbolic.MacawExt arch) ret ->
+  GP.Personality cExt sym (Symbolic.MacawExt arch) ret ->
   CR.RecordState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   CR.ReplayState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   p
-mkGreaseSimulatorState toConcVar dbgCtx recState repState =
+mkGreaseSimulatorState pers recState repState =
   GreaseSimulatorState
-    { _discoveredFnHandles = Map.empty
-    , _toConcretize = toConcVar
+    { _gssPersonality = pers
+    , _discoveredFnHandles = Map.empty
     , _syscallHandles = MapF.empty
     , _macawLazySimulatorState = Symbolic.emptyMacawLazySimulatorState
-    , _serverSocketFds = Map.empty
-    , _dbgContext = dbgCtx
     , _gssRecordState = recState
     , _gssReplayState = repState
     }
@@ -178,11 +169,15 @@ instance
   (ret ~ Symbolic.ArchRegStruct arch) =>
   Dbg.HasContext (GreaseSimulatorState cExt sym arch ret) cExt sym (Symbolic.MacawExt arch) ret
   where
-  context = dbgContext
+  context = gssPersonality . GP.pDbgContext
   {-# INLINE context #-}
 
 instance ToConc.HasToConcretize (GreaseSimulatorState cExt sym arch ret) where
-  toConcretize = Lens.view toConcretize
+  toConcretize = Lens.view (gssPersonality . GP.pToConcretize)
+
+instance GP.HasPersonality (GreaseSimulatorState cExt sym arch ret) cExt sym (Symbolic.MacawExt arch) ret where
+  personality = gssPersonality
+  {-# INLINE personality #-}
 
 instance
   (MC.ArchAddrWidth arch ~ ww) =>
@@ -204,7 +199,7 @@ instance
   greaseSimulatorState = id
 
 instance GSN.HasServerSocketFds (GreaseSimulatorState cExt sym arch ret) where
-  serverSocketFdsL = serverSocketFds
+  serverSocketFdsL = gssPersonality . GP.pServerSocketFds
 
 instance
   CR.HasRecordState

--- a/grease/src/Grease/Personality.hs
+++ b/grease/src/Grease/Personality.hs
@@ -1,0 +1,71 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FunctionalDependencies #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+-- |
+-- Copyright        : (c) Galois, Inc. 2026
+-- Maintainer       : GREASE Maintainers <grease@galois.com>
+--
+-- The shared parts of all @grease@ personality types. Both the Macaw personality
+-- ('Grease.Macaw.SimulatorState.GreaseSimulatorState') and the LLVM personality
+-- ('Grease.LLVM.Personality.GreaseLLVMPersonality') embed a 'Personality'.
+module Grease.Personality (
+  -- * @Personality@
+  Personality (..),
+  HasPersonality (..),
+
+  -- * Lenses for @Personality@
+  pDbgContext,
+  pToConcretize,
+  pServerSocketFds,
+) where
+
+import Control.Lens (Lens')
+import Control.Lens.TH (makeLenses)
+import Data.Kind (Type)
+import Data.Map.Strict qualified as Map
+import Data.Parameterized.Some (Some)
+import Grease.Concretize.ToConcretize qualified as ToConc
+import Grease.SimulatorState.Networking qualified as GSN
+import Lang.Crucible.Debug qualified as Dbg
+import Lang.Crucible.Simulator qualified as CS
+import Lang.Crucible.Types (CrucibleType)
+
+-- | The shared personality core for @grease@.
+--
+-- This type holds state that is common to both the Macaw and LLVM personality
+-- types. See 'Lang.Crucible.Simulator.cruciblePersonality'.
+--
+-- Type parameters:
+--
+-- - @cExt@: debugger command extension type
+-- - @sym@: the symbolic backend expression type
+-- - @ext@: the Crucible language extension (e.g., @'Data.Macaw.Symbolic.MacawExt' arch@ or @'Lang.Crucible.LLVM.LLVM'@)
+-- - @ret@: the Crucible return type
+type Personality ::
+  Type ->
+  Type ->
+  Type ->
+  CrucibleType ->
+  Type
+data Personality cExt sym ext ret = Personality
+  { _pDbgContext :: Dbg.Context cExt sym ext ret
+  -- ^ The debugger context for interactive debugging.
+  , _pToConcretize :: CS.GlobalVar ToConc.ToConcretizeType
+  -- ^ Values created during runtime to be passed to the concretization
+  -- functionality and generally displayed to the user.
+  , _pServerSocketFds :: Map.Map Integer (Some GSN.ServerSocketInfo)
+  -- ^ A map from registered socket file descriptors to their corresponding
+  -- metadata. See @Note [The networking story]@ in
+  -- "Grease.Overrides.Networking".
+  }
+
+makeLenses ''Personality
+
+-- | A class for personality types that contain a 'Personality' core.
+class HasPersonality p cExt sym ext ret | p -> cExt sym ext ret where
+  personality :: Lens' p (Personality cExt sym ext ret)
+
+instance HasPersonality (Personality cExt sym ext ret) cExt sym ext ret where
+  personality = id
+  {-# INLINE personality #-}

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -96,6 +96,7 @@ import Grease.Macaw.SimulatorHooks qualified as GMSH
 import Grease.Macaw.SimulatorState qualified as GMSS
 import Grease.Options qualified as GO
 import Grease.Output (renderJSON)
+import Grease.Personality qualified as GP
 import Grease.Pretty (prettyPtrFnMap)
 import Grease.Refine qualified as GR
 import Grease.Refine.Diagnostic qualified as RDiag
@@ -1187,8 +1188,14 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
         gssRecState <- RR.mkRecordState halloc
         gssEmpTrace <- RR.emptyRecordedTrace sym
         gssRepState <- RR.mkReplayState halloc gssEmpTrace
+        let gssPers =
+              GP.Personality
+                { GP._pDbgContext = dbgCtx
+                , GP._pToConcretize = toConcVar
+                , GP._pServerSocketFds = Map.empty
+                }
         let greaseSimState =
-              GMSS.mkGreaseSimulatorState toConcVar dbgCtx gssRecState gssRepState
+              GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
                 & GMSS.discoveredFnHandles .~ discoveredHdls
         personality <-
           SP.mkScreachSimulatorState

--- a/screach/src/Screach/Personality.hs
+++ b/screach/src/Screach/Personality.hs
@@ -25,6 +25,7 @@ import Data.Parameterized.Ctx qualified as C
 import GHC.TypeLits (type Natural)
 import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Macaw.SimulatorState qualified as GMSS
+import Grease.Personality qualified as GP
 import Grease.SimulatorState.Networking qualified as GSN
 import Lang.Crucible.Debug qualified as Dbg
 import Lang.Crucible.FunctionHandle (HandleAllocator)
@@ -116,6 +117,18 @@ instance
   where
   greaseSimulatorState = greaseSimulatorState
   {-# INLINE greaseSimulatorState #-}
+
+instance
+  (ext ~ MS.MacawExt arch, ret ~ MS.ArchRegStruct arch) =>
+  GP.HasPersonality
+    (ScreachSimulatorState p sym bak ext arch t ret aty w)
+    MDebug.MacawCommand
+    sym
+    ext
+    ret
+  where
+  personality = greaseSimulatorState . GMSS.gssPersonality
+  {-# INLINE personality #-}
 
 instance ToConc.HasToConcretize (ScreachSimulatorState p sym bak ext arch t ret aty w) where
   toConcretize = Lens.view (greaseSimulatorState . Lens.to ToConc.toConcretize)


### PR DESCRIPTION
Another refactoring to prepare for #446.

Next steps will be:

- Adding LLVM memory var to `Personality`
- Adding `RefineData` to `Personality`
- Moving the map `IORef` into `RefineData`