### PR TITLE
Store `RefineData` in the personality

### DIFF
--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -140,6 +140,7 @@ import Grease.Personality qualified as GP
 import Grease.Pretty (prettyPtrFnMap)
 import Grease.Profiler.Feature (greaseProfilerFeature)
 import Grease.Refine qualified as GRef
+import Grease.Refine.RefinementData qualified as GRef
 import Grease.Setup qualified as GSetup
 import Grease.Shape (ArgShapes, ExtShape)
 import Grease.Shape qualified as Shape
@@ -671,7 +672,7 @@ macawMemConfig ::
   , MSM.MacawProcessAssertion sym
   , ?memOpts :: CLM.MemOptions
   , ?lc :: CLTC.TypeContext
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak scope cExt arch ret argTys wptr
   , ToConc.HasToConcretize p
   ) =>
   GDiag.GreaseLogAction ->
@@ -759,7 +760,7 @@ macawInitState ::
   , ext ~ Symbolic.MacawExt arch
   , ret ~ Symbolic.ArchRegStruct arch
   , argTys ~ Symbolic.CtxToCrucibleType (Symbolic.ArchRegContext arch)
-  , p ~ GreaseSimulatorState MDebug.MacawCommand sym arch ret
+  , p ~ GreaseSimulatorState sym bak scope MDebug.MacawCommand arch ret argTys wptr
   , CLM.HasLLVMAnn sym
   , ?memOpts :: CLM.MemOptions
   , ?lc :: CLTC.TypeContext
@@ -779,12 +780,13 @@ macawInitState ::
   -- entrypoint function. Otherwise, this is 'Nothing'.
   Maybe (MC.ArchSegmentOff arch) ->
   EP.EntrypointCfgs (C.SomeCFG ext (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch) ret) ->
+  GRef.RefinementData sym bak scope ext argTys wptr ->
   C.GlobalVar ToConc.ToConcretizeType ->
   GSetup.SetupMem sym ->
   GSIO.InitializedFs sym wptr ->
   GSetup.Args sym ext (Symbolic.MacawCrucibleRegTypes arch) wptr ->
   IO (CS.ExecState p sym ext (CS.RegEntry sym ret))
-macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable execCallback setupHook addrOvs mbCfgAddr entrypointCfgsSsa toConcVar setupMem initFs args = do
+macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable execCallback setupHook addrOvs mbCfgAddr entrypointCfgsSsa refineData toConcVar setupMem initFs args = do
   let sym = CB.backendGetSym bak
   regs <- liftIO (overrideRegs archCtx sym (GSetup.argVals args))
   EP.EntrypointCfgs
@@ -813,7 +815,7 @@ macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable e
   empTrace <- CR.emptyRecordedTrace sym
   repState <- CR.mkReplayState halloc empTrace
 
-  let pers = GP.mkPersonality memVar dbgCtx toConcVar
+  let pers = GP.mkPersonality memVar dbgCtx toConcVar refineData
   let personality =
         mkGreaseSimulatorState pers recState repState
           & discoveredFnHandles .~ discoveredHdls
@@ -834,7 +836,7 @@ macawRefineOnce ::
   , wptr ~ MC.ArchAddrWidth arch
   , ext ~ Symbolic.MacawExt arch
   , ret ~ Symbolic.ArchRegStruct arch
-  , p ~ GreaseSimulatorState MDebug.MacawCommand sym arch ret
+  , p ~ GreaseSimulatorState sym bak scope MDebug.MacawCommand arch ret argTys wptr
   , CLM.HasLLVMAnn sym
   , ?memOpts :: CLM.MemOptions
   , ?lc :: CLTC.TypeContext
@@ -1396,7 +1398,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
   let memVar = CLT.llvmMemVar llvmCtx
   (execFeats, profLogTask) <-
     llvmExecFeats
-      @(GLP.GreaseLLVMPersonality LDebug.LLVMCommand sym ret)
+      @(GLP.GreaseLLVMPersonality sym bak t LDebug.LLVMCommand ret argTys (CLLVM.ArchWidth arch))
       la
       bak
       simOpts
@@ -1449,8 +1451,8 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
         initMem
         heuristics
         execFeats
-        $ \toConc setupMem initFs args -> do
-          let llvmPers = GP.mkPersonality memVar dbgCtx toConc
+        $ \refineData toConc setupMem initFs args -> do
+          let llvmPers = GP.mkPersonality memVar dbgCtx toConc refineData
           let p =
                 GLP.mkGreaseLLVMPersonality llvmPers recState repState
           LLVM.initState

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -261,6 +261,7 @@ library
     Grease.Pretty
     Grease.Refine
     Grease.Refine.Diagnostic
+    Grease.Refine.RefinementData
     Grease.Scheduler
     Grease.Setup
     Grease.Setup.Annotations

--- a/grease/src/Grease/LLVM/Personality.hs
+++ b/grease/src/Grease/LLVM/Personality.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableSuperClasses #-}
@@ -22,6 +23,7 @@ import Control.Lens (Lens')
 import Control.Lens qualified as Lens
 import Control.Lens.TH (makeLenses)
 import Data.Kind (Type)
+import GHC.TypeLits (type Natural)
 import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Personality qualified as GP
 import Grease.SimulatorState.Networking qualified as GSN
@@ -30,29 +32,38 @@ import Lang.Crucible.LLVM (LLVM)
 import Lang.Crucible.Simulator qualified as CS
 import Lang.Crucible.Simulator.RecordAndReplay qualified as CR
 import Lang.Crucible.Types (CrucibleType)
+import Lang.Crucible.Types qualified as CT (Ctx)
 
 -- | The Crucible state extension for holding LLVM-specific @grease@ state.
 type GreaseLLVMPersonality ::
-  -- @cExt@: debugger command extension type
-  Type ->
   -- @sym@: the symbolic backend expression type
+  Type ->
+  -- @bak@: the symbolic backend type
+  Type ->
+  -- @t@: the nonce generator scope
+  Type ->
+  -- @cExt@: debugger command extension type
   Type ->
   -- @ret@: the Crucible return type
   CrucibleType ->
+  -- @argTys@: Crucible argument types for the target function
+  CT.Ctx CrucibleType ->
+  -- @wptr@: pointer width
+  Natural ->
   Type
-data GreaseLLVMPersonality cExt sym ret
+data GreaseLLVMPersonality sym bak t cExt ret argTys wptr
   = GreaseLLVMPersonality
-  { _llvmPersonality :: GP.Personality cExt sym LLVM ret
+  { _llvmPersonality :: GP.Personality sym bak t cExt LLVM ret argTys wptr
   -- ^ The shared personality core. See 'Grease.Personality.Personality'.
   , _llvmRecordState ::
       CR.RecordState
-        (GreaseLLVMPersonality cExt sym ret)
+        (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
         sym
         LLVM
         (CS.RegEntry sym ret)
   , _llvmReplayState ::
       CR.ReplayState
-        (GreaseLLVMPersonality cExt sym ret)
+        (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
         sym
         LLVM
         (CS.RegEntry sym ret)
@@ -62,9 +73,9 @@ makeLenses ''GreaseLLVMPersonality
 
 -- | Create a 'GreaseLLVMPersonality' with the given configuration.
 mkGreaseLLVMPersonality ::
-  forall cExt sym ret p.
-  (p ~ GreaseLLVMPersonality cExt sym ret) =>
-  GP.Personality cExt sym LLVM ret ->
+  forall sym bak t cExt ret argTys wptr p.
+  (p ~ GreaseLLVMPersonality sym bak t cExt ret argTys wptr) =>
+  GP.Personality sym bak t cExt LLVM ret argTys wptr ->
   CR.RecordState p sym LLVM (CS.RegEntry sym ret) ->
   CR.ReplayState p sym LLVM (CS.RegEntry sym ret) ->
   p
@@ -76,37 +87,37 @@ mkGreaseLLVMPersonality pers recState repState =
     }
 
 class
-  GP.HasPersonality p cExt sym LLVM ret =>
-  HasGreaseLLVMPersonality p cExt sym ret
-    | p -> cExt sym ret
+  GP.HasPersonality p sym bak t cExt LLVM ret argTys wptr =>
+  HasGreaseLLVMPersonality p sym bak t cExt ret argTys wptr
+    | p -> sym bak t cExt ret argTys wptr
   where
-  greaseLlvmPersonality :: Lens' p (GreaseLLVMPersonality cExt sym ret)
+  greaseLlvmPersonality :: Lens' p (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
 
-instance HasGreaseLLVMPersonality (GreaseLLVMPersonality cExt sym ret) cExt sym ret where
+instance HasGreaseLLVMPersonality (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) sym bak t cExt ret argTys wptr where
   greaseLlvmPersonality = id
   {-# INLINE greaseLlvmPersonality #-}
 
-instance Dbg.HasContext (GreaseLLVMPersonality cExt sym ret) cExt sym LLVM ret where
+instance Dbg.HasContext (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) cExt sym LLVM ret where
   context = llvmPersonality . GP.pDbgContext
   {-# INLINE context #-}
 
-instance GP.HasMemVar (GreaseLLVMPersonality cExt sym ret) where
+instance GP.HasMemVar (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) where
   getMemVar = Lens.view (llvmPersonality . GP.pMemVar)
 
-instance ToConc.HasToConcretize (GreaseLLVMPersonality cExt sym ret) where
+instance ToConc.HasToConcretize (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) where
   toConcretize = Lens.view (llvmPersonality . GP.pToConcretize)
 
-instance GSN.HasServerSocketFds (GreaseLLVMPersonality cExt sym ret) where
+instance GSN.HasServerSocketFds (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) where
   serverSocketFdsL = llvmPersonality . GP.pServerSocketFds
 
-instance GP.HasPersonality (GreaseLLVMPersonality cExt sym ret) cExt sym LLVM ret where
+instance GP.HasPersonality (GreaseLLVMPersonality sym bak t cExt ret argTys wptr) sym bak t cExt LLVM ret argTys wptr where
   personality = llvmPersonality
   {-# INLINE personality #-}
 
 instance
   CR.HasRecordState
-    (GreaseLLVMPersonality cExt sym ret)
-    (GreaseLLVMPersonality cExt sym ret)
+    (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
+    (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
     sym
     LLVM
     (CS.RegEntry sym ret)
@@ -116,8 +127,8 @@ instance
 
 instance
   CR.HasReplayState
-    (GreaseLLVMPersonality cExt sym ret)
-    (GreaseLLVMPersonality cExt sym ret)
+    (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
+    (GreaseLLVMPersonality sym bak t cExt ret argTys wptr)
     sym
     LLVM
     (CS.RegEntry sym ret)

--- a/grease/src/Grease/Macaw.hs
+++ b/grease/src/Grease/Macaw.hs
@@ -408,7 +408,7 @@ memConfigInitial bak arch ptrTable skipUnsupportedRelocs relocs =
 --   'mkMacawOverrideMap' would in turn need the 'Symbolic.MemModelConfig' that
 --   the combined function would produce, leading to a cycle.)
 memConfigWithHandles ::
-  forall arch sym bak solver scope st fs p cExt ret.
+  forall arch sym bak solver scope st fs p cExt ret argTys wptr.
   ( C.IsSyntaxExtension (Symbolic.MacawExt arch)
   , CB.IsSymBackend sym bak
   , Symbolic.SymArchConstraints arch
@@ -419,7 +419,7 @@ memConfigWithHandles ::
   , Show (ArchReloc arch)
   , ?memOpts :: CLM.MemOptions
   , CLM.HasLLVMAnn sym
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak scope cExt arch ret argTys wptr
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , HasToConcretize p
   ) =>
@@ -503,7 +503,7 @@ assertRelocSupported arch loc (CLM.LLVMPointer _base offset) relocs =
           pure ()
 
 initState ::
-  forall arch sym bak t solver scope st fs p cExt ret.
+  forall arch sym bak t solver scope st fs p cExt ret argTys wptr.
   ( CB.IsSymBackend sym bak
   , sym ~ WEB.ExprBuilder scope st fs
   , bak ~ CB.OnlineBackend solver scope st fs
@@ -515,7 +515,7 @@ initState ::
   , CLM.HasLLVMAnn sym
   , MSM.MacawProcessAssertion sym
   , ?memOpts :: CLM.MemOptions
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   , HasToConcretize p
   ) =>
   bak ->

--- a/grease/src/Grease/Macaw/Overrides.hs
+++ b/grease/src/Grease/Macaw/Overrides.hs
@@ -206,13 +206,14 @@ mkMacawOverrideMap bak builtinOvs userOvPaths halloc archCtx = do
 
 -- | Like 'mkMacawOverrideMap', with 'builtinStubsOverrides'.
 mkMacawOverrideMapWithBuiltins ::
+  forall solver sym bak scope st fs arch p t cExt ret argTys wptr.
   ( OnlineSolverAndBackend solver sym bak scope st fs
   , ?memOpts :: CLM.MemOptions
   , ?lc :: TypeContext
   , CLM.HasLLVMAnn sym
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , Symbolic.SymArchConstraints arch
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   -- | The paths of each user-supplied override file.

--- a/grease/src/Grease/Macaw/Overrides/Builtin.hs
+++ b/grease/src/Grease/Macaw/Overrides/Builtin.hs
@@ -45,14 +45,14 @@ import Text.LLVM.AST qualified as L
 -- c.f. 'builtinLLVMOverrides', which includes all of the functions here (i.e.,
 -- from libc) and then some (i.e., LLVM intrinsics).
 builtinStubsOverrides ::
-  forall sym p arch cExt ret.
+  forall sym p arch bak t cExt ret argTys wptr.
   ( CB.IsSymInterface sym
   , ?memOpts :: CLM.MemOptions
   , ?lc :: CLTC.TypeContext
   , CLM.HasLLVMAnn sym
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , MM.MemWidth (MC.ArchAddrWidth arch)
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   C.GlobalVar CLM.Mem ->
   Symbolic.MemModelConfig p sym arch CLM.Mem ->

--- a/grease/src/Grease/Macaw/Overrides/Networking.hs
+++ b/grease/src/Grease/Macaw/Overrides/Networking.hs
@@ -40,7 +40,7 @@ networkOverrides ::
   , ?memOpts :: CLM.MemOptions
   , MC.MemWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   CLSIO.LLVMFileSystem w ->
   CS.GlobalVar CLM.Mem ->
@@ -60,7 +60,7 @@ networkOverrides fs memVar mmConf =
 buildAcceptOverride ::
   ( CLM.HasPtrWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   CLSIO.LLVMFileSystem w ->
   StubsF.FunctionOverride
@@ -84,7 +84,7 @@ buildBindOverride ::
   , ?memOpts :: CLM.MemOptions
   , MC.MemWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   CS.GlobalVar CLM.Mem ->
   MS.MemModelConfig p sym arch CLM.Mem ->
@@ -106,7 +106,7 @@ buildBindOverride memVar mmConf =
 buildConnectOverride ::
   ( CLM.HasPtrWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   StubsF.FunctionOverride
     p
@@ -126,7 +126,7 @@ buildConnectOverride =
 buildListenOverride ::
   ( CLM.HasPtrWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   StubsF.FunctionOverride
     p
@@ -190,7 +190,7 @@ buildSendOverride fs memVar =
 buildSocketOverride ::
   ( CLM.HasPtrWidth w
   , w ~ MC.ArchAddrWidth arch
-  , GMSS.HasGreaseSimulatorState p cExt sym arch ret
+  , GMSS.HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   CLSIO.LLVMFileSystem w ->
   StubsF.FunctionOverride

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -148,12 +148,13 @@ newtype LookupFunctionHandleDispatch p sym arch
 -- found) if they can be found, and if not, skips them by simulating them as
 -- no-ops.
 defaultLookupFunctionHandleDispatch ::
+  forall solver sym bak t st fs arch p cExt ret argTys wptr.
   ( OnlineSolverAndBackend solver sym bak t st fs
   , Symbolic.SymArchConstraints arch
   , CLM.HasLLVMAnn sym
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , HasToConcretize p
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   GreaseLogAction ->
@@ -243,10 +244,10 @@ data LookupFunctionHandleResult p sym arch where
 --
 -- The behavior of this function is documented in @doc/function-calls.md@.
 lookupFunctionHandleResult ::
-  forall arch sym bak solver scope st fs p rtp blocks r ctx cExt ret.
+  forall arch sym bak solver scope st fs p rtp blocks r ctx cExt ret t argTys wptr.
   ( OnlineSolverAndBackend solver sym bak scope st fs
   , Symbolic.SymArchConstraints arch
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   GreaseLogAction ->
@@ -416,9 +417,10 @@ lookupFunctionHandleResult bak la halloc arch memory symMap pltStubs dynFunMap f
         pure (SkippedFunctionCall (NotExecutable funcAddrOff), st)
 
 lookupFunctionHandle ::
+  forall solver sym bak t st fs arch p cExt ret argTys wptr.
   ( OnlineSolverAndBackend solver sym bak t st fs
   , Symbolic.SymArchConstraints arch
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   GreaseLogAction ->
@@ -531,8 +533,9 @@ data LookupSyscallResult p sym arch atps rtps where
 --
 -- The behavior of this function is documented in @doc/syscalls.md@.
 lookupSyscallResult ::
+  forall sym bak p t cExt arch ret argTys wptr atps rtps rtp blocks r ctx.
   ( CB.IsSymBackend sym bak
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   ArchContext arch ->
@@ -578,8 +581,9 @@ lookupSyscallResult bak arch syscallOvs errorSymbolicSyscalls atps rtps st regs 
 -- | An implementation of 'Symbolic.LookupSyscallHandle' that attempts to look
 -- up a syscall override and dispatches on the result.
 lookupSyscallHandle ::
+  forall sym bak p t cExt arch ret argTys wptr.
   ( CB.IsSymBackend sym bak
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   bak ->
   ArchContext arch ->
@@ -601,8 +605,9 @@ lookupSyscallHandle bak arch syscallOvs errorSymbolicSyscalls lsd =
 -- code discovery]@ in "Grease.Macaw.SimulatorState") and bind the function
 -- handle to its CFG.
 discoverFuncAddr ::
+  forall arch p bak t cExt sym ret argTys wptr r f a.
   ( Symbolic.SymArchConstraints arch
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   LJ.LogAction IO Diagnostic ->
   C.HandleAllocator ->

--- a/grease/src/Grease/Macaw/SetupHook.hs
+++ b/grease/src/Grease/Macaw/SetupHook.hs
@@ -57,13 +57,13 @@ doLog la diag = LJ.writeLog la (MacawSetupHookDiagnostic diag)
 -- c.f. 'Grease.LLVM.SetupHook.SetupHook'
 newtype SetupHook sym arch
   = SetupHook
-      ( forall bak rtp a r solver scope st fs p cExt ret.
+      ( forall bak rtp a r solver scope st fs p cExt ret t argTys wptr.
         ( CB.IsSymBackend sym bak
         , sym ~ WEB.ExprBuilder scope st fs
         , bak ~ LCB.OnlineBackend solver scope st fs
         , WPO.OnlineSolver solver
         , CLM.HasLLVMAnn sym
-        , HasGreaseSimulatorState p cExt sym arch ret
+        , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
         , HasToConcretize p
         ) =>
         bak ->

--- a/grease/src/Grease/Macaw/SimulatorState.hs
+++ b/grease/src/Grease/Macaw/SimulatorState.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE UndecidableInstances #-}
@@ -38,6 +39,7 @@ import Data.Macaw.Symbolic qualified as Symbolic
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Context qualified as Ctx
 import Data.Parameterized.Map qualified as MapF
+import GHC.TypeLits (type Natural)
 import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Personality qualified as GP
 import Grease.SimulatorState.Networking qualified as GSN
@@ -50,17 +52,25 @@ import Stubs.Syscall qualified as Stubs
 
 -- | The Crucible state extension for holding @grease@-specific state.
 type GreaseSimulatorState ::
-  -- @cExt@: debugger command extension type
-  Type ->
   -- @sym@: the symbolic backend expression type
+  Type ->
+  -- @bak@: the symbolic backend type
+  Type ->
+  -- @t@: the nonce generator scope
+  Type ->
+  -- @cExt@: debugger command extension type
   Type ->
   -- @arch@: the machine code architecture
   Type ->
   -- @ret@: the Crucible return type (usually @'Symbolic.ArchRegStruct' arch@)
   CT.CrucibleType ->
+  -- @argTys@: Crucible argument types for the target function
+  CT.Ctx CT.CrucibleType ->
+  -- @wptr@: pointer width
+  Natural ->
   Type
-data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
-  { _gssPersonality :: GP.Personality cExt sym (Symbolic.MacawExt arch) ret
+data GreaseSimulatorState sym bak t cExt arch ret argTys wptr = GreaseSimulatorState
+  { _gssPersonality :: GP.Personality sym bak t cExt (Symbolic.MacawExt arch) ret argTys wptr
   -- ^ The shared personality core. See 'Grease.Personality.Personality'.
   , _discoveredFnHandles :: Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch)
   -- ^ A map of discovered function addresses to their handles. Any time a new
@@ -95,13 +105,13 @@ data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
   -- which @grease@ is built.
   , _gssRecordState ::
       CR.RecordState
-        (GreaseSimulatorState cExt sym arch ret)
+        (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
         sym
         (Symbolic.MacawExt arch)
         (CS.RegEntry sym ret)
   , _gssReplayState ::
       CR.ReplayState
-        (GreaseSimulatorState cExt sym arch ret)
+        (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
         sym
         (Symbolic.MacawExt arch)
         (CS.RegEntry sym ret)
@@ -109,9 +119,9 @@ data GreaseSimulatorState cExt sym arch ret = GreaseSimulatorState
 
 -- | Create a 'GreaseSimulatorState' with the given configuration.
 mkGreaseSimulatorState ::
-  forall cExt sym arch ret p.
-  (p ~ GreaseSimulatorState cExt sym arch ret) =>
-  GP.Personality cExt sym (Symbolic.MacawExt arch) ret ->
+  forall sym bak t cExt arch ret argTys wptr p.
+  (p ~ GreaseSimulatorState sym bak t cExt arch ret argTys wptr) =>
+  GP.Personality sym bak t cExt (Symbolic.MacawExt arch) ret argTys wptr ->
   CR.RecordState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   CR.ReplayState p sym (Symbolic.MacawExt arch) (CS.RegEntry sym ret) ->
   p
@@ -133,12 +143,12 @@ mkGreaseSimulatorState pers recState repState =
 class
   ( Symbolic.HasMacawLazySimulatorState p sym (MC.ArchAddrWidth arch)
   , GSN.HasServerSocketFds p
-  , GP.HasPersonality p cExt sym (Symbolic.MacawExt arch) ret
+  , GP.HasPersonality p sym bak t cExt (Symbolic.MacawExt arch) ret argTys wptr
   ) =>
-  HasGreaseSimulatorState p cExt sym arch ret
-    | p -> cExt sym arch ret
+  HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
+    | p -> sym bak t cExt arch ret argTys wptr
   where
-  greaseSimulatorState :: Lens' p (GreaseSimulatorState cExt sym arch ret)
+  greaseSimulatorState :: Lens' p (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
 
 -----
 -- These types should probably be defined in Grease.Macaw.FunctionOverride, but
@@ -169,25 +179,25 @@ makeLenses ''GreaseSimulatorState
 
 instance
   (ret ~ Symbolic.ArchRegStruct arch) =>
-  Dbg.HasContext (GreaseSimulatorState cExt sym arch ret) cExt sym (Symbolic.MacawExt arch) ret
+  Dbg.HasContext (GreaseSimulatorState sym bak t cExt arch ret argTys wptr) cExt sym (Symbolic.MacawExt arch) ret
   where
   context = gssPersonality . GP.pDbgContext
   {-# INLINE context #-}
 
-instance GP.HasMemVar (GreaseSimulatorState cExt sym arch ret) where
+instance GP.HasMemVar (GreaseSimulatorState sym bak t cExt arch ret argTys wptr) where
   getMemVar = Lens.view (gssPersonality . GP.pMemVar)
 
-instance ToConc.HasToConcretize (GreaseSimulatorState cExt sym arch ret) where
+instance ToConc.HasToConcretize (GreaseSimulatorState sym bak t cExt arch ret argTys wptr) where
   toConcretize = Lens.view (gssPersonality . GP.pToConcretize)
 
-instance GP.HasPersonality (GreaseSimulatorState cExt sym arch ret) cExt sym (Symbolic.MacawExt arch) ret where
+instance GP.HasPersonality (GreaseSimulatorState sym bak t cExt arch ret argTys wptr) sym bak t cExt (Symbolic.MacawExt arch) ret argTys wptr where
   personality = gssPersonality
   {-# INLINE personality #-}
 
 instance
   (MC.ArchAddrWidth arch ~ ww) =>
   Symbolic.HasMacawLazySimulatorState
-    (GreaseSimulatorState cExt sym arch ret)
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
     sym
     ww
   where
@@ -195,21 +205,25 @@ instance
 
 instance
   HasGreaseSimulatorState
-    (GreaseSimulatorState cExt sym arch ret)
-    cExt
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
     sym
+    bak
+    t
+    cExt
     arch
     ret
+    argTys
+    wptr
   where
   greaseSimulatorState = id
 
-instance GSN.HasServerSocketFds (GreaseSimulatorState cExt sym arch ret) where
+instance GSN.HasServerSocketFds (GreaseSimulatorState sym bak t cExt arch ret argTys wptr) where
   serverSocketFdsL = gssPersonality . GP.pServerSocketFds
 
 instance
   CR.HasRecordState
-    (GreaseSimulatorState cExt sym arch ret)
-    (GreaseSimulatorState cExt sym arch ret)
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
     sym
     (Symbolic.MacawExt arch)
     (CS.RegEntry sym ret)
@@ -219,8 +233,8 @@ instance
 
 instance
   CR.HasReplayState
-    (GreaseSimulatorState cExt sym arch ret)
-    (GreaseSimulatorState cExt sym arch ret)
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
+    (GreaseSimulatorState sym bak t cExt arch ret argTys wptr)
     sym
     (Symbolic.MacawExt arch)
     (CS.RegEntry sym ret)
@@ -229,7 +243,7 @@ instance
   {-# INLINE replayState #-}
 
 stateDiscoveredFnHandles ::
-  HasGreaseSimulatorState p cExt sym arch ret =>
+  HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr =>
   Lens'
     (CS.SimState p sym ext r f a)
     (Map.Map (MC.ArchSegmentOff arch) (MacawFnHandle arch))
@@ -240,7 +254,7 @@ stateDiscoveredFnHandles =
     . discoveredFnHandles
 
 stateSyscallHandles ::
-  HasGreaseSimulatorState p cExt sym arch ret =>
+  HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr =>
   Lens'
     (CS.SimState p sym ext r f a)
     (MapF.MapF Stubs.SyscallNumRepr Stubs.SyscallFnHandle)
@@ -251,7 +265,7 @@ stateSyscallHandles =
     . syscallHandles
 
 stateMacawLazySimulatorState ::
-  HasGreaseSimulatorState p cExt sym arch ret =>
+  HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr =>
   Lens'
     (CS.SimState p sym ext r f a)
     (Symbolic.MacawLazySimulatorState sym (MC.ArchAddrWidth arch))

--- a/grease/src/Grease/Personality.hs
+++ b/grease/src/Grease/Personality.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE FunctionalDependencies #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -25,6 +26,7 @@ module Grease.Personality (
   pDbgContext,
   pToConcretize,
   pServerSocketFds,
+  pRefinementData,
 ) where
 
 import Control.Lens (Lens', (^.))
@@ -33,13 +35,16 @@ import Control.Lens.TH (makeLenses)
 import Data.Kind (Type)
 import Data.Map.Strict qualified as Map
 import Data.Parameterized.Some (Some)
+import GHC.TypeLits (type Natural)
 import Grease.Concretize.ToConcretize qualified as ToConc
+import Grease.Refine.RefinementData (RefinementData)
 import Grease.SimulatorState.Networking qualified as GSN
 import Lang.Crucible.Debug qualified as Dbg
 import Lang.Crucible.LLVM.MemModel qualified as CLM
 import Lang.Crucible.Simulator qualified as CS
 import Lang.Crucible.Simulator.ExecutionTree qualified as ET
 import Lang.Crucible.Types (CrucibleType)
+import Lang.Crucible.Types qualified as CT (Ctx)
 
 -- | The shared personality core for @grease@.
 --
@@ -48,17 +53,25 @@ import Lang.Crucible.Types (CrucibleType)
 --
 -- Type parameters:
 --
--- - @cExt@: debugger command extension type
 -- - @sym@: the symbolic backend expression type
+-- - @bak@: the symbolic backend type
+-- - @t@: the nonce generator scope
+-- - @cExt@: debugger command extension type
 -- - @ext@: the Crucible language extension (e.g., @'Data.Macaw.Symbolic.MacawExt' arch@ or @'Lang.Crucible.LLVM.LLVM'@)
 -- - @ret@: the Crucible return type
+-- - @argTys@: Crucible argument types for the target function
+-- - @wptr@: pointer width
 type Personality ::
   Type ->
   Type ->
   Type ->
+  Type ->
+  Type ->
   CrucibleType ->
+  CT.Ctx CrucibleType ->
+  Natural ->
   Type
-data Personality cExt sym ext ret = Personality
+data Personality sym bak t cExt ext ret argTys wptr = Personality
   { _pMemVar :: CS.GlobalVar CLM.Mem
   -- ^ The global variable holding the LLVM memory model state.
   , _pDbgContext :: Dbg.Context cExt sym ext ret
@@ -70,6 +83,9 @@ data Personality cExt sym ext ret = Personality
   -- ^ A map from registered socket file descriptors to their corresponding
   -- metadata. See @Note [The networking story]@ in
   -- "Grease.Overrides.Networking".
+  , _pRefinementData :: RefinementData sym bak t ext argTys wptr
+  -- ^ Refinement-specific state, used by both @grease@ and @screach@ during
+  -- their respective refinement loops.
   }
 
 makeLenses ''Personality
@@ -80,13 +96,15 @@ mkPersonality ::
   CS.GlobalVar CLM.Mem ->
   Dbg.Context cExt sym ext ret ->
   CS.GlobalVar ToConc.ToConcretizeType ->
-  Personality cExt sym ext ret
-mkPersonality memVar dbgCtx toConc =
+  RefinementData sym bak t ext argTys wptr ->
+  Personality sym bak t cExt ext ret argTys wptr
+mkPersonality memVar dbgCtx toConc refineData =
   Personality
     { _pMemVar = memVar
     , _pDbgContext = dbgCtx
     , _pToConcretize = toConc
     , _pServerSocketFds = Map.empty
+    , _pRefinementData = refineData
     }
 
 -- | A class for personality types that contain an LLVM memory model
@@ -94,7 +112,7 @@ mkPersonality memVar dbgCtx toConc =
 class HasMemVar p where
   getMemVar :: p -> CS.GlobalVar CLM.Mem
 
-instance HasMemVar (Personality cExt sym ext ret) where
+instance HasMemVar (Personality sym bak t cExt ext ret argTys wptr) where
   getMemVar = Lens.view pMemVar
 
 -- | Extract the memory model 'CS.GlobalVar' from a 'CS.SimState'.
@@ -112,9 +130,9 @@ execStateMemVar ::
 execStateMemVar st = getMemVar (ET.execStateContext st ^. CS.cruciblePersonality)
 
 -- | A class for personality types that contain a 'Personality' core.
-class HasMemVar p => HasPersonality p cExt sym ext ret | p -> cExt sym ext ret where
-  personality :: Lens' p (Personality cExt sym ext ret)
+class HasMemVar p => HasPersonality p sym bak t cExt ext ret argTys wptr | p -> sym bak t cExt ext ret argTys wptr where
+  personality :: Lens' p (Personality sym bak t cExt ext ret argTys wptr)
 
-instance HasPersonality (Personality cExt sym ext ret) cExt sym ext ret where
+instance HasPersonality (Personality sym bak t cExt ext ret argTys wptr) sym bak t cExt ext ret argTys wptr where
   personality = id
   {-# INLINE personality #-}

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -69,7 +69,6 @@ module Grease.Refine (
   NoHeuristic (..),
   proveAndRefine,
   ExecData (..),
-  RefinementData (..),
   refineOnce,
   execAndRefine,
   RefinementSummary (..),
@@ -119,14 +118,14 @@ import Grease.Options (BoundsOpts)
 import Grease.Options qualified as Opts
 import Grease.Personality qualified as GP
 import Grease.Refine.Diagnostic qualified as Diag
+import Grease.Refine.RefinementData qualified as RD
 import Grease.Scheduler qualified as Sched
 import Grease.Setup (InitialMem)
 import Grease.Setup qualified as Setup
-import Grease.Setup.Annotations qualified as Anns
 import Grease.Shape (ArgShapes, ExtShape, PrettyExt)
 import Grease.Shape.NoTag (NoTag)
 import Grease.Shape.Pointer (PtrDataMode (Precond), PtrShape)
-import Grease.Solver (Solver, solverAdapter)
+import Grease.Solver (solverAdapter)
 import Grease.SymIO qualified as GSIO
 import Grease.Utility (tshow)
 import Grease.ValueName (ValueName)
@@ -317,21 +316,22 @@ consumer ::
   bak ->
   CS.ExecResult p sym ext r ->
   GreaseLogAction ->
-  Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym) ->
-  RefinementData sym bak ext argTys w ->
+  RD.RefinementData sym bak t ext argTys w ->
   C.ProofConsumer sym t (ProveRefineResult sym ext argTys)
-consumer bak execResult la bbMap refineData = do
-  let RefinementData
-        { refineAnns = anns
-        , refineArgNames = argNames
-        , refineArgShapes = argShapes
-        , refineHeuristics = heuristics
-        , refineInitState = initState
+consumer bak execResult la refineData = do
+  let RD.RefinementData
+        { RD.refineAnns = anns
+        , RD.refineArgNames = argNames
+        , RD.refineArgShapes = argShapes
+        , RD.refineHeuristics = heuristics
+        , RD.refineInitState = initState
+        , RD.refineErrMap = errMapRef
         } = refineData
   C.ProofConsumer $ \goal result -> do
     let sym = CB.backendGetSym bak
     let lp = CB.proofGoal goal
     let simErr = lp ^. W4.labeledPredMsg
+    bbMap <- readIORef errMapRef
     minfo <- lookupErrorInfo sym la (lp ^. W4.labeledPred) simErr bbMap
     case result of
       C.Proved{} -> do
@@ -416,18 +416,6 @@ execCfg bak execData = do
         o <- CB.getProofObligations bak
         pure (r, o, Seq.empty)
 
--- | Data needed for refinement
-data RefinementData sym bak ext argTys wptr
-  = RefinementData
-  { refineAnns :: Anns.Annotations sym ext argTys
-  , refineArgNames :: Ctx.Assignment ValueName argTys
-  , refineArgShapes :: ArgShapes ext NoTag argTys
-  , refineHeuristics :: [RefineHeuristic sym bak ext argTys]
-  , refineInitState :: Conc.InitialState sym ext argTys wptr
-  , refineSolver :: Solver
-  , refineSolverTimeout :: C.Timeout
-  }
-
 -- | Helper, not exported
 proveAndRefine ::
   forall p ext r solver sym bak t st argTys w fm.
@@ -442,17 +430,16 @@ proveAndRefine ::
   bak ->
   CS.ExecResult p sym ext r ->
   GreaseLogAction ->
-  Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym) ->
-  RefinementData sym bak ext argTys w ->
+  RD.RefinementData sym bak t ext argTys w ->
   CB.ProofObligations sym ->
   IO (ProveRefineResult sym ext argTys)
-proveAndRefine bak execResult la bbMap refineData goals = do
+proveAndRefine bak execResult la refineData goals = do
   let sym = CB.backendGetSym bak
-  let solver = refineSolver refineData
-  let tout = refineSolverTimeout refineData
+  let solver = RD.refineSolver refineData
+  let tout = RD.refineSolverTimeout refineData
   let prover = C.offlineProver tout sym W4.defaultLogData (solverAdapter solver)
   let strat = C.ProofStrategy prover combiner
-  let cons = consumer bak execResult la bbMap refineData
+  let cons = consumer bak execResult la refineData
   case goals of
     Nothing -> pure ProveSuccess
     Just goals' ->
@@ -499,11 +486,10 @@ execAndRefine ::
   bak ->
   W4FM.FloatModeRepr fm ->
   GreaseLogAction ->
-  RefinementData sym bak ext argTys w ->
-  IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym)) ->
+  RD.RefinementData sym bak t ext argTys w ->
   ExecData p sym ext ret ->
   m (ProveRefineResult sym ext argTys)
-execAndRefine bak _fm la refineData bbMapRef execData = do
+execAndRefine bak _fm la refineData execData = do
   let memVar = GP.execStateMemVar (execInitState execData)
   let refineOne initSt = do
         let execData' = execData{execInitState = initSt}
@@ -512,9 +498,8 @@ execAndRefine bak _fm la refineData bbMapRef execData = do
         refineResult <-
           case processExecResult execResult of
             Just cantRefine -> pure (ProveCantRefine cantRefine)
-            Nothing -> do
-              bbMap <- readIORef bbMapRef
-              proveAndRefine bak execResult la bbMap refineData goals
+            Nothing ->
+              proveAndRefine bak execResult la refineData goals
         case execPathStrat execData of
           Opts.Dfs -> do
             loc <- WI.getCurrentProgramLoc (CB.backendGetSym bak)
@@ -604,6 +589,7 @@ refineOnce ::
   ( ( MSM.MacawProcessAssertion sym
     , Mem.HasLLVMAnn sym
     ) =>
+    RD.RefinementData sym bak t ext argTys wptr ->
     C.GlobalVar ToConc.ToConcretizeType ->
     Setup.SetupMem sym ->
     GSIO.InitializedFs sym wptr ->
@@ -626,7 +612,6 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
   initFs_ <- GSIO.initialLlvmFileSystem halloc sym (Opts.simFsOpts simOpts)
   (toConc, globals1) <- liftIO $ ToConc.newToConcretize halloc (GSIO.initFsGlobals initFs_)
   let initFs = initFs_{GSIO.initFsGlobals = globals1}
-  st <- mkInitState toConc setupMem initFs args
   let concInitState =
         Conc.InitialState
           { Conc.initStateArgs = args
@@ -634,6 +619,18 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
           , Conc.initStateMem = initMem
           }
   let boundsOpts = Opts.simBoundsOpts simOpts
+  let refineData =
+        RD.RefinementData
+          { RD.refineAnns = setupAnns
+          , RD.refineArgNames = argNames
+          , RD.refineArgShapes = argShapes
+          , RD.refineHeuristics = heuristics
+          , RD.refineInitState = concInitState
+          , RD.refineSolver = Opts.simSolver simOpts
+          , RD.refineSolverTimeout = Opts.simSolverTimeout boundsOpts
+          , RD.refineErrMap = bbMapRef
+          }
+  st <- mkInitState refineData toConc setupMem initFs args
   boundsFeats_ <- boundedExecFeats boundsOpts
   let boundsFeats = List.map CS.genericToExecutionFeature boundsFeats_
   let execData =
@@ -642,17 +639,7 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
           , execInitState = st
           , execPathStrat = Opts.simPathStrategy simOpts
           }
-  let refineData =
-        RefinementData
-          { refineAnns = setupAnns
-          , refineArgNames = argNames
-          , refineArgShapes = argShapes
-          , refineHeuristics = heuristics
-          , refineInitState = concInitState
-          , refineSolver = Opts.simSolver simOpts
-          , refineSolverTimeout = Opts.simSolverTimeout boundsOpts
-          }
-  execAndRefine bak fm la refineData bbMapRef execData
+  execAndRefine bak fm la refineData execData
 
 data RefinementSummary sym ext tys
   = RefinementSuccess (ArgShapes ext NoTag tys)

--- a/grease/src/Grease/Refine/RefinementData.hs
+++ b/grease/src/Grease/Refine/RefinementData.hs
@@ -1,0 +1,51 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE ExplicitNamespaces #-}
+
+-- |
+-- Copyright        : (c) Galois, Inc. 2026
+-- Maintainer       : GREASE Maintainers <grease@galois.com>
+--
+-- The 'RefinementData' type.
+module Grease.Refine.RefinementData (
+  RefinementData (..),
+) where
+
+import Data.IORef (IORef)
+import Data.Kind (Type)
+import Data.Map.Strict qualified as Map
+import Data.Parameterized.Context qualified as Ctx
+import Data.Parameterized.Nonce (Nonce)
+import GHC.TypeLits (type Natural)
+import Grease.Concretize qualified as Conc
+import Grease.ErrorDescription (ErrorDescription)
+import Grease.Heuristic (RefineHeuristic)
+import Grease.Setup.Annotations qualified as Anns
+import Grease.Shape (ArgShapes)
+import Grease.Shape.NoTag (NoTag)
+import Grease.Solver (Solver)
+import Grease.ValueName (ValueName)
+import Lang.Crucible.Types qualified as C
+import Lang.Crucible.Utils.Timeout qualified as C
+
+-- | Data needed for refinement.
+--
+-- Type parameters:
+--
+-- - @sym@: the symbolic backend expression type
+-- - @bak@: the symbolic backend type
+-- - @t@: the nonce generator scope
+-- - @ext@: the Crucible language extension
+-- - @argTys@: Crucible argument types for the target function
+-- - @wptr@: pointer width
+type RefinementData :: Type -> Type -> Type -> Type -> Ctx.Ctx C.CrucibleType -> Natural -> Type
+data RefinementData sym bak t ext argTys wptr
+  = RefinementData
+  { refineAnns :: Anns.Annotations sym ext argTys
+  , refineArgNames :: Ctx.Assignment ValueName argTys
+  , refineArgShapes :: ArgShapes ext NoTag argTys
+  , refineHeuristics :: [RefineHeuristic sym bak ext argTys]
+  , refineInitState :: Conc.InitialState sym ext argTys wptr
+  , refineSolver :: Solver
+  , refineSolverTimeout :: C.Timeout
+  , refineErrMap :: IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym))
+  }

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -100,6 +100,7 @@ import Grease.Personality qualified as GP
 import Grease.Pretty (prettyPtrFnMap)
 import Grease.Refine qualified as GR
 import Grease.Refine.Diagnostic qualified as RDiag
+import Grease.Refine.RefinementData qualified as GR
 import Grease.Scheduler qualified as Sched
 import Grease.Setup qualified as GS
 import Grease.Shape qualified as Shape
@@ -1186,6 +1187,7 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
                 , GR.refineInitState = concInitState
                 , GR.refineSolver = Conf.solver conf
                 , GR.refineSolverTimeout = GO.simSolverTimeout boundsOpts
+                , GR.refineErrMap = bbMapRef
                 }
         let dbgOpts = Conf.debugOpts conf
         let dbgCmdExt = MDebug.macawCommandExt (archCtx ^. Arch.archVals)
@@ -1193,7 +1195,7 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
         gssRecState <- RR.mkRecordState halloc
         gssEmpTrace <- RR.emptyRecordedTrace sym
         gssRepState <- RR.mkReplayState halloc gssEmpTrace
-        let gssPers = GP.mkPersonality memVar dbgCtx toConcVar
+        let gssPers = GP.mkPersonality memVar dbgCtx toConcVar refineData
         let greaseSimState =
               GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
                 & GMSS.discoveredFnHandles .~ discoveredHdls
@@ -1202,11 +1204,6 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
             sym
             halloc
             greaseSimState
-            RFT.SrchRefineData
-              { RFT._greaseRefineData = refineData
-              , RFT._refineErrMap = bbMapRef
-              , RFT._refineResult = Nothing
-              }
         GM.initState
           bak
           gla
@@ -1372,11 +1369,8 @@ handleTarget ::
     Bool
 handleTarget archCtx _ sla initArgs st =
   let argNames = archCtx ^. Arch.archValueNames
-      rst =
-        ( CS.execResultContext st ^. CS.cruciblePersonality . RFT.refinementState ::
-            RFT.SrchRefineData sym bak t ext aty wptr
-        )
-   in case RFT._refineResult rst of
+      pers = CS.execResultContext st ^. CS.cruciblePersonality
+   in case pers ^. SP.refineResult of
         Just (RFT.RefineResult bid cData _trace) | isReachedBug bid -> do
           let addrWidth = archCtx ^. Arch.archInfo . to MAI.archAddrWidth
           let interestingShapes = interestingConcretizedShapes argNames initArgs (Conc.concArgs cData)
@@ -1612,6 +1606,9 @@ verifyReachable ::
   , ToConc.HasToConcretize p
   , ?memOpts :: CLM.MemOptions
   , Shape.ExtShape ext ~ Shape.PtrShape ext w
+  , ext ~ MS.MacawExt arch
+  , ret ~ MS.ArchRegStruct arch
+  , MC.MemWidth w
   ) =>
   ScreachLogAction ->
   GreaseLogAction ->
@@ -1645,13 +1642,10 @@ verifyReachable la gla bak initShape genericExecFeats refineResults = do
     result' <- CS.executeCrucible (replay : execFeats) st'
 
     let ctx = CSE.execResultContext result'
-    let RFT.SrchRefineData
-          { RFT._greaseRefineData = refineData
-          , RFT._refineErrMap = errMapRef
-          } = ctx ^. CS.cruciblePersonality . to SP._refineState
+    let pers = ctx ^. CS.cruciblePersonality
+    let refineData = pers ^. GP.personality . GP.pRefinementData
     obls <- CB.getProofObligations bak
-    errMap <- IORef.readIORef errMapRef
-    refResult <- GR.proveAndRefine bak result' gla errMap refineData obls
+    refResult <- GR.proveAndRefine bak result' gla refineData obls
     case refResult of
       GR.ProveBug bugInstance _
         | isReachedBug bugInstance ->

--- a/screach/src/Screach/Personality.hs
+++ b/screach/src/Screach/Personality.hs
@@ -10,6 +10,7 @@ module Screach.Personality (
   recordState,
   replayState,
   distState,
+  refineResult,
   mkScreachSimulatorState,
 ) where
 
@@ -49,13 +50,13 @@ import Screach.ShortestDistanceScheduler qualified as ShortDistSched
 type ScreachSimulatorState ::
   Type -> Type -> Type -> Type -> Type -> Type -> CT.CrucibleType -> C.Ctx CT.CrucibleType -> Natural -> Type
 data ScreachSimulatorState p sym bak ext arch t ret aty w = ScreachSimulatorState
-  { _greaseSimulatorState :: GMSS.GreaseSimulatorState MDebug.MacawCommand sym arch ret
+  { _greaseSimulatorState :: GMSS.GreaseSimulatorState sym bak t MDebug.MacawCommand arch ret aty w
   , _distState :: IORef Dist.DijkstraCaches
   , _recordState ::
       CSR.RecordState (ScreachSimulatorState p sym bak ext arch t ret aty w) sym ext (CS.RegEntry sym ret)
   , _replayState ::
       CSR.ReplayState (ScreachSimulatorState p sym bak ext arch t ret aty w) sym ext (CS.RegEntry sym ret)
-  , _refineState :: RFT.SrchRefineData sym bak t ext aty w
+  , _refineResult :: Maybe (RFT.RefineResult sym ext aty)
   }
 
 makeLenses ''ScreachSimulatorState
@@ -110,10 +111,14 @@ instance
   (MC.ArchAddrWidth arch ~ w, ext ~ MS.MacawExt arch, ret ~ MS.ArchRegStruct arch) =>
   GMSS.HasGreaseSimulatorState
     (ScreachSimulatorState p sym bak ext arch t ret aty w)
-    MDebug.MacawCommand
     sym
+    bak
+    t
+    MDebug.MacawCommand
     arch
     ret
+    aty
+    w
   where
   greaseSimulatorState = greaseSimulatorState
   {-# INLINE greaseSimulatorState #-}
@@ -122,10 +127,14 @@ instance
   (ext ~ MS.MacawExt arch, ret ~ MS.ArchRegStruct arch) =>
   GP.HasPersonality
     (ScreachSimulatorState p sym bak ext arch t ret aty w)
-    MDebug.MacawCommand
     sym
+    bak
+    t
+    MDebug.MacawCommand
     ext
     ret
+    aty
+    w
   where
   personality = greaseSimulatorState . GMSS.gssPersonality
   {-# INLINE personality #-}
@@ -137,25 +146,18 @@ instance ToConc.HasToConcretize (ScreachSimulatorState p sym bak ext arch t ret 
   toConcretize = Lens.view (greaseSimulatorState . Lens.to ToConc.toConcretize)
 
 instance
-  RFT.HasRefinmentState
-    (ScreachSimulatorState p sym bak ext arch t ret aty w)
-    sym
-    bak
-    t
-    ext
-    aty
-    w
+  (ext ~ MS.MacawExt arch) =>
+  RFT.HasRefineResult (ScreachSimulatorState p sym bak ext arch t ret aty w) sym ext aty
   where
-  refinementState = refineState
+  refineResult = refineResult
 
 mkScreachSimulatorState ::
   forall sym bak t ext aty arch p ret w.
   sym ->
   HandleAllocator ->
-  GMSS.GreaseSimulatorState MDebug.MacawCommand sym arch ret ->
-  RFT.SrchRefineData sym bak t ext aty w ->
+  GMSS.GreaseSimulatorState sym bak t MDebug.MacawCommand arch ret aty w ->
   IO (ScreachSimulatorState p sym bak ext arch t ret aty w)
-mkScreachSimulatorState sym halloc gss schrRefineData = do
+mkScreachSimulatorState sym halloc gss = do
   recState <- CSR.mkRecordState halloc
   empTrace <- CSR.emptyRecordedTrace sym
   repState <- CSR.mkReplayState halloc empTrace
@@ -166,6 +168,6 @@ mkScreachSimulatorState sym halloc gss schrRefineData = do
       , _distState = distRef
       , _recordState = recState
       , _replayState = repState
-      , _refineState = schrRefineData
+      , _refineResult = Nothing
       }
 {-# INLINEABLE mkScreachSimulatorState #-}

--- a/screach/src/Screach/RefineFeature.hs
+++ b/screach/src/Screach/RefineFeature.hs
@@ -6,16 +6,11 @@
 {-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Screach.RefineFeature (
   refineFeature,
-  HasRefinmentState (..),
-  SrchRefineData (..),
   RefineResult (..),
-  greaseRefineData,
-  refineResult,
-  refineErrMap,
+  HasRefineResult (..),
   HasScreachPersonality,
   sdseExecFeatures,
 ) where
@@ -24,25 +19,23 @@ import Control.Lens ((&), (.~), (?~), (^.))
 import Control.Lens qualified as Lens
 import Control.Monad.IO.Class (MonadIO)
 import Data.Data (Proxy (Proxy))
-import Data.IORef (IORef, modifyIORef', newIORef, readIORef)
-import Data.Kind (Constraint, Type)
+import Data.IORef (IORef, modifyIORef', newIORef)
+import Data.Kind (Type)
 import Data.Macaw.CFG qualified as MC
 import Data.Map qualified as Map
 import Data.Parameterized.Ctx (Ctx)
-import Data.Parameterized.Nonce (Nonce)
 import Data.Parameterized.Nonce qualified as Nonce
 import GHC.IORef qualified as IORef
-import GHC.TypeLits (type Natural)
 import Grease.Bug qualified as GR
 import Grease.Concretize qualified as GR
 import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.Diagnostic qualified as GrDiag
-import Grease.ErrorDescription (ErrorDescription)
 import Grease.Heuristic qualified as GH
 import Grease.Personality qualified as GP
 import Grease.Refine qualified as GR
 import Grease.Refine.Diagnostic qualified as GRDiag
+import Grease.Refine.RefinementData qualified as GR
 import Grease.Scheduler qualified as Sched
 import Grease.Shape (ArgShapes, ExtShape)
 import Grease.Shape.NoTag qualified as Shape
@@ -81,49 +74,18 @@ data RefineResult sym ext aty
   , refineResultTrace :: CR.RecordedTrace sym
   }
 
--- | Per-'ExecState' data needed for refinement.
---
--- Type parameters:
---
--- - @sym@: instance of 'Lang.Crucible.Backend.IsSymInterface'
--- - @bak@: instance of @'Lang.Crucible.Backend.IsSymBackend' sym@
--- - @scope@ type-level nonce generator name for 'What4.Expr.Expr'
--- - @ext@: language extension, see "Lang.Crucible.CFG.Extension"
--- - @aty@: Crucible argument types for the target function
--- - @w@: pointer width (Natural)
-type SrchRefineData ::
-  Type ->
-  Type ->
-  Type ->
-  Type ->
-  Ctx CT.CrucibleType ->
-  Natural ->
-  Type
-data SrchRefineData sym bak scope ext aty w = SrchRefineData
-  { _refineErrMap :: IORef (Map.Map (Nonce scope CT.BaseBoolType) (ErrorDescription sym))
-  , _greaseRefineData :: GR.RefinementData sym bak ext aty w
-  , _refineResult :: Maybe (RefineResult sym ext aty)
-  -- ^ At termination if this is a ProveBug we store the CEX
-  -- and details about what bug this CEX is for
-  }
+-- | Class for personality types that hold a 'RefineResult'.
+class HasRefineResult p sym ext tys | p -> sym ext tys where
+  refineResult :: Lens.Lens' p (Maybe (RefineResult sym ext tys))
 
-Lens.makeLenses ''SrchRefineData
-
-type HasRefinmentState ::
-  Type -> Type -> Type -> Type -> Type -> CT.Ctx CT.CrucibleType -> Natural -> Constraint
-
--- | Class for Refinement state, each state has to hold onto its
--- refinement data for `proveAndRefine`
-class HasRefinmentState p sym bak t ext aty w | p -> sym ext where
-  refinementState :: Lens.Lens' p (SrchRefineData sym bak t ext aty w)
-
--- | Constraints for collaboration between the scheduler
--- refinement and record replay so that refinement can add
+-- | Constraints for collaboration between the scheduler,
+-- refinement, and record/replay so that refinement can add
 -- saved states to a new state and setup replay on that new initial
--- state
-type HasScreachPersonality p sym bak t ext tys ret rtp w =
+-- state.
+type HasScreachPersonality p sym bak t cExt ext tys ret rtp w =
   ( CS.RegEntry sym ret ~ rtp
-  , HasRefinmentState p sym bak t ext tys w
+  , GP.HasPersonality p sym bak t cExt ext ret tys w
+  , HasRefineResult p sym ext tys
   , CR.HasReplayState p p sym ext (CS.RegEntry sym ret)
   , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
   , GP.HasMemVar p
@@ -176,12 +138,13 @@ doLog la diag = LJ.writeLog la (Diag.RunDiagnostic diag)
 -- either queues a refinement, a state with bug information for a found bug,
 -- or continues if the state is proven safe.
 refineState ::
-  forall solver sym bak t st fm ext w p rtp tys ret.
+  forall solver sym bak t st fm ext w p rtp tys ret cExt.
   ( ?memOpts :: CLM.MemOptions
   , OnlineSolverAndBackend solver sym bak t st (WE.Flags fm)
   , ExtShape ext ~ PtrShape ext w
   , C.IsSyntaxExtension ext
-  , HasRefinmentState p sym bak t ext tys w
+  , GP.HasPersonality p sym bak t cExt ext ret tys w
+  , HasRefineResult p sym ext tys
   , CR.HasReplayState p p sym ext (CS.RegEntry sym ret)
   , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
   , CB.IsSymInterface sym
@@ -207,13 +170,13 @@ refineState ::
     (C.ExecutionFeatureResult p sym ext rtp)
 refineState bak sla gla refineReplay st config = do
   let pers = C.execResultContext st ^. C.cruciblePersonality
-  let SrchRefineData{_greaseRefineData = rdata, _refineErrMap = errMapRef} = Lens.view refinementState pers
+  let rdata = pers ^. GP.personality . GP.pRefinementData
+  let errMapRef = GR.refineErrMap rdata
   let memVar = GP.getMemVar pers
   LJ.writeLog gla (GrDiag.RefineDiagnostic (GRDiag.ExecutionResult memVar st))
   obls <- C.withBackend (C.execResultContext st) $ \bak' ->
     CB.getProofObligations bak'
-  errMap <- readIORef errMapRef
-  refResult <- GR.proveAndRefine bak st gla errMap rdata obls
+  refResult <- GR.proveAndRefine bak st gla rdata obls
   trc <- getRecordedTrace st
   case refResult of
     GR.ProveSuccess -> do
@@ -227,13 +190,9 @@ refineState bak sla gla refineReplay st config = do
       pure C.ExecutionFeatureNoChange
     GR.ProveBug bi cdata ->
       let
-        rstate :: Lens.Lens' (C.ExecResult p sym ext rtp) (SrchRefineData sym bak t ext tys w)
-        rstate = Sched.execResultContextLens . C.cruciblePersonality . refinementState
-        nres =
-          st
-            & rstate
-              . refineResult
-              ?~ RefineResult bi cdata trc
+        rresultL :: Lens.Lens' (C.ExecResult p sym ext rtp) (Maybe (RefineResult sym ext tys))
+        rresultL = Sched.execResultContextLens . C.cruciblePersonality . refineResult
+        nres = st & rresultL ?~ RefineResult bi cdata trc
        in
         pure $
           C.ExecutionFeatureModifiedState $
@@ -272,11 +231,12 @@ refineState bak sla gla refineReplay st config = do
 -- | A feature that uses GREASE to refine states where the obligations are not provable and restart the symbolic executor
 -- or annotates the state with bug information (if a potential bug is found.)
 refineFeature ::
+  forall solver sym bak t st fm ext w p tys ret rtp cExt.
   ( ?memOpts :: CLM.MemOptions
   , OnlineSolverAndBackend solver sym bak t st (WE.Flags fm)
   , ExtShape ext ~ PtrShape ext w
   , C.IsSyntaxExtension ext
-  , HasScreachPersonality p sym bak t ext tys ret rtp w
+  , HasScreachPersonality p sym bak t cExt ext tys ret rtp w
   , CB.IsSymInterface sym
   , ToConc.HasToConcretize p
   , 16 CT.<= w
@@ -307,16 +267,17 @@ refineFeature bak sla gla refineReplay initCfg = C.ExecutionFeature $ \case
 --
 -- Returns the features and an IO action to retrieve saved target results.
 sdseExecFeatures ::
-  forall rtp sym ret p ext scope st fs bak solver tys w fm.
+  forall rtp sym ret p ext t st fs bak solver tys w fm cExt.
   ( rtp ~ CS.RegEntry sym ret
   , CB.IsSymInterface sym
-  , sym ~ WE.ExprBuilder scope st fs
-  , bak ~ CBO.OnlineBackend solver scope st fs
+  , sym ~ WE.ExprBuilder t st fs
+  , bak ~ CBO.OnlineBackend solver t st fs
   , ExtShape ext ~ PtrShape ext w
   , WPO.OnlineSolver solver
   , WE.Flags fm ~ fs
   , C.IsSyntaxExtension ext
-  , HasRefinmentState p sym bak scope ext tys w
+  , GP.HasPersonality p sym bak t cExt ext ret tys w
+  , HasRefineResult p sym ext tys
   , ToConc.HasToConcretize p
   , GP.HasMemVar p
   , 16 CT.<= w
@@ -333,12 +294,12 @@ sdseExecFeatures ::
   -- | The function that creates a new initial state from a fresh argument spec and
   -- an annotation map of errors.
   ( ArgShapes ext Shape.NoTag tys ->
-    Maybe (IORef.IORef (Map.Map (Nonce.Nonce scope CT.BaseBoolType) (GH.ErrorDescription sym))) ->
+    Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CT.BaseBoolType) (GH.ErrorDescription sym))) ->
     IO (C.ExecState p sym ext (CS.RegEntry sym ret))
   ) ->
   Sched.PrioritizationFunction p sym ext rtp ->
   -- | Determines if a given state is the target state for SDSE
-  (HasRefinmentState p sym bak scope ext tys w => C.ExecResult p sym ext rtp -> IO Bool) ->
+  (C.ExecResult p sym ext rtp -> IO Bool) ->
   RftOpt.AllSolutions ->
   -- | Returns the features and an IORef to retrieve 'RefineResult's after execution
   IO ([C.ExecutionFeature p sym ext (CS.RegEntry sym ret)], IORef [RefineResult sym ext tys])
@@ -352,9 +313,8 @@ sdseExecFeatures bak sla gla refineReplay initCFG priorityFunc isTargetPred (Rft
         t <- isTargetPred r
         if t
           then do
-            let rst :: SrchRefineData sym bak scope ext tys w
-                rst = C.execResultContext r ^. C.cruciblePersonality . refinementState
-            case rst ^. refineResult of
+            let pers = C.execResultContext r ^. C.cruciblePersonality
+            case pers ^. refineResult of
               Just rr -> modifyIORef' refineResultsRef (rr :)
               _ -> pure ()
             if exploreMore

--- a/screach/src/Screach/ResolveCall.hs
+++ b/screach/src/Screach/ResolveCall.hs
@@ -23,7 +23,7 @@ import What4.FunctionName qualified as WFN
 -- dynamic loader by the time the ECFS file is created.
 ecfsLookupFunctionHandleDispatch ::
   ( Symbolic.SymArchConstraints arch
-  , HasGreaseSimulatorState p cExt sym arch ret
+  , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
   ) =>
   GreaseLogAction ->
   CFH.HandleAllocator ->


### PR DESCRIPTION
Another step towards featurization of GREASE (#446).

- Add `refineErrMap` to `RefineData`
- Put `RefineData` in `Personality`
- Reorder some initialization to make this work
- Update refinement in both codebases to use all this