### PR TITLE
Simplify handling of error annotation map

### DIFF
--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -255,16 +255,9 @@ data ErrorCallbacks sym t
 -- to the 'errorMap' as an 'ErrorDescription'
 buildErrMaps ::
   sym ~ WE.ExprBuilder t st fs =>
-  Maybe
-    ( IORef
-        ( Map.Map
-            (Nonce t C.BaseBoolType)
-            (ErrorDescription sym)
-        )
-    ) ->
   IO (ErrorCallbacks sym t)
-buildErrMaps mbBBMap = do
-  bbMapRef <- Maybe.maybe (newIORef Map.empty) pure mbBBMap
+buildErrMaps = do
+  bbMapRef <- newIORef Map.empty
   let recordLLVMAnnotation callStack (Mem.BoolAnn ann) bb =
         modifyIORef bbMapRef $
           Map.insert ann (CrucibleLLVMError bb callStack)
@@ -604,7 +597,7 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
     , llvmErrCallback = recordLLVMAnnotation
     , macawAssertionCallback = processMacawAssert
     } <-
-    buildErrMaps Nothing
+    buildErrMaps
   let ?recordLLVMAnnotation = recordLLVMAnnotation
   let ?processMacawAssert = processMacawAssert
   (args, setupMem, setupAnns) <-

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -993,12 +993,11 @@ initCFG ::
     ext
     Shape.NoTag
     aty ->
-  Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CCC.BaseBoolType) (GH.ErrorDescription sym))) ->
   IO
     (CS.ExecState (SP.ScreachSimulatorState p sym bak ext arch t ret aty 64) sym ext (CS.RegEntry sym ret))
 initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
   let discoveredHdls = Maybe.maybe Map.empty (`Map.singleton` CCC.cfgHandle entryRegSsaCfg) mbEntryAddr
-   in \bak gla sla macawCfgConfig halloc conf archCtx mbTargetAddr mbStartupOvSomeSsaCfg rtLoc memVar setupHook execAction addrOvs argShapes mbErrMaps -> do
+   in \bak gla sla macawCfgConfig halloc conf archCtx mbTargetAddr mbStartupOvSomeSsaCfg rtLoc memVar setupHook execAction addrOvs argShapes -> do
         let dataLayout = macawDataLayout archCtx
         let rNames = archCtx ^. Arch.archRegNames
             argNames = archCtx ^. Arch.archValueNames
@@ -1019,7 +1018,7 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbEntryAddr =
           , GR.llvmErrCallback = recordLLVMAnnotation
           , GR.macawAssertionCallback = processMacawAssert
           } <-
-          GR.buildErrMaps mbErrMaps
+          GR.buildErrMaps
 
         let addrWidth = MC.addrWidthRepr (Proxy @64)
         LJ.writeLog
@@ -1579,7 +1578,7 @@ analyzeCfg conf sla gla halloc macawCfgConfig archCtx mbEhi setupHook rtLoc exec
             ]
 
     setupAssertThenAssume bak
-    firstState <- initShape initArgs Nothing
+    firstState <- initShape initArgs
     _result <- CS.executeCrucible startFeats firstState
     refineResults <- IORef.readIORef savedRef
     doLog sla $ Diag.RefinementResultCount $ length refineResults
@@ -1613,10 +1612,7 @@ verifyReachable ::
   ScreachLogAction ->
   GreaseLogAction ->
   bak ->
-  ( Shape.ArgShapes ext Shape.NoTag tys ->
-    Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CT.BaseBoolType) (GH.ErrorDescription sym))) ->
-    IO (CS.ExecState p sym ext (CS.RegEntry sym ret))
-  ) ->
+  (Shape.ArgShapes ext Shape.NoTag tys -> IO (CS.ExecState p sym ext (CS.RegEntry sym ret))) ->
   [CS.GenericExecutionFeature sym] ->
   [RFT.RefineResult sym ext tys] ->
   IO ()
@@ -1627,7 +1623,7 @@ verifyReachable la gla bak initShape genericExecFeats refineResults = do
         concArgShapes = Conc.concArgsShapes (Conc.concArgs cData)
         untagArgs = TFC.fmapFC (TFC.fmapFC (const Shape.NoTag)) concArgShapes
     -- TODO(internal#144): Incorporate the concretized filesystem.
-    st <- initShape (Shape.ArgShapes untagArgs) Nothing
+    st <- initShape (Shape.ArgShapes untagArgs)
 
     let trace = RFT.refineResultTrace rr
     let st' =

--- a/screach/src/Screach/RefineFeature.hs
+++ b/screach/src/Screach/RefineFeature.hs
@@ -22,16 +22,12 @@ import Data.Data (Proxy (Proxy))
 import Data.IORef (IORef, modifyIORef', newIORef)
 import Data.Kind (Type)
 import Data.Macaw.CFG qualified as MC
-import Data.Map qualified as Map
 import Data.Parameterized.Ctx (Ctx)
-import Data.Parameterized.Nonce qualified as Nonce
-import GHC.IORef qualified as IORef
 import Grease.Bug qualified as GR
 import Grease.Concretize qualified as GR
 import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Diagnostic (GreaseLogAction)
 import Grease.Diagnostic qualified as GrDiag
-import Grease.Heuristic qualified as GH
 import Grease.Personality qualified as GP
 import Grease.Refine qualified as GR
 import Grease.Refine.Diagnostic qualified as GRDiag
@@ -160,18 +156,13 @@ refineState ::
   GreaseLogAction ->
   RftOpt.RefineReplay ->
   C.ExecResult p sym ext rtp ->
-  -- | A function that initializes a new crucible state from the argument specification and
-  -- an annotation map of term nonces to error descriptions.
-  ( ArgShapes ext Shape.NoTag tys ->
-    Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CT.BaseBoolType) (GH.ErrorDescription sym))) ->
-    IO (C.ExecState p sym ext (CS.RegEntry sym ret))
-  ) ->
+  -- | A function that initializes a new crucible state from the argument specification.
+  (ArgShapes ext Shape.NoTag tys -> IO (C.ExecState p sym ext (CS.RegEntry sym ret))) ->
   IO
     (C.ExecutionFeatureResult p sym ext rtp)
 refineState bak sla gla refineReplay st config = do
   let pers = C.execResultContext st ^. C.cruciblePersonality
   let rdata = pers ^. GP.personality . GP.pRefinementData
-  let errMapRef = GR.refineErrMap rdata
   let memVar = GP.getMemVar pers
   LJ.writeLog gla (GrDiag.RefineDiagnostic (GRDiag.ExecutionResult memVar st))
   obls <- C.withBackend (C.execResultContext st) $ \bak' ->
@@ -206,10 +197,7 @@ refineState bak sla gla refineReplay st config = do
         )
       CB.clearProofObligations bak
       CB.resetAssumptionState bak
-      initSt <-
-        config
-          shp
-          (Just errMapRef)
+      initSt <- config shp
 
       C.ExecutionFeatureNewState
         <$> pauseLinearState
@@ -247,10 +235,7 @@ refineFeature ::
   ScreachLogAction ->
   GreaseLogAction ->
   RftOpt.RefineReplay ->
-  ( ArgShapes ext Shape.NoTag tys ->
-    Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CT.BaseBoolType) (GH.ErrorDescription sym))) ->
-    IO (C.ExecState p sym ext (CS.RegEntry sym ret))
-  ) ->
+  (ArgShapes ext Shape.NoTag tys -> IO (C.ExecState p sym ext (CS.RegEntry sym ret))) ->
   C.ExecutionFeature p sym ext rtp
 refineFeature bak sla gla refineReplay initCfg = C.ExecutionFeature $ \case
   C.ResultState (C.TimeoutResult _) -> do
@@ -291,12 +276,8 @@ sdseExecFeatures ::
   ScreachLogAction ->
   GreaseLogAction ->
   RftOpt.RefineReplay ->
-  -- | The function that creates a new initial state from a fresh argument spec and
-  -- an annotation map of errors.
-  ( ArgShapes ext Shape.NoTag tys ->
-    Maybe (IORef.IORef (Map.Map (Nonce.Nonce t CT.BaseBoolType) (GH.ErrorDescription sym))) ->
-    IO (C.ExecState p sym ext (CS.RegEntry sym ret))
-  ) ->
+  -- | The function that creates a new initial state from a fresh argument spec.
+  (ArgShapes ext Shape.NoTag tys -> IO (C.ExecState p sym ext (CS.RegEntry sym ret))) ->
   Sched.PrioritizationFunction p sym ext rtp ->
   -- | Determines if a given state is the target state for SDSE
   (C.ExecResult p sym ext rtp -> IO Bool) ->


### PR DESCRIPTION
Create a fresh map per refinement. This should allow us to throw away old error annotations, saving memory. It also simplifies some APIs.