### PR TITLE
screach: Improve logging of aborted paths

### DIFF
--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -78,6 +78,8 @@ module Grease.Refine (
   -- The following are used by a downstream project
 
   -- * Implementation details
+  processExecResult,
+  shortResult,
   findPredAnnotations,
 ) where
 
@@ -535,25 +537,26 @@ execAndRefine bak _fm la refineData execData = do
               Left C.TimedOut -> pure (ProveCantRefine SolverTimeout)
               Right combinedResult -> pure (C.subgoalResult combinedResult)
   liftIO (go refineResult)
- where
-  -- Very short summary for single-line log message
-  shortResult =
-    \case
-      ProveSuccess -> "success"
-      ProveBug{} -> "likely bug"
-      ProveNoHeuristic{} -> "possible bug"
-      ProveRefine{} -> "refined precondition"
-      ProveCantRefine (Exhausted{}) -> "resource exhausted"
-      ProveCantRefine (Exit (Just code)) -> "exited with " <> tshow code
-      ProveCantRefine (Exit Nothing) -> "exited"
-      ProveCantRefine (MissingFunc (Just nm)) -> "missing function " <> Text.pack nm
-      ProveCantRefine (MissingFunc{}) -> "missing function"
-      ProveCantRefine (MissingSemantics{}) -> "missing semantics"
-      ProveCantRefine (MutableGlobal{}) -> "load from mut global"
-      ProveCantRefine (SolverTimeout{}) -> "solver timeout"
-      ProveCantRefine (SolverUnknown{}) -> "solver unknown"
-      ProveCantRefine (Timeout{}) -> "symex timeout"
-      ProveCantRefine (Unsupported{}) -> "unsupported feature"
+
+-- | Very short summary of a 'ProveRefineResult' for single-line log messages.
+shortResult :: ProveRefineResult sym ext argTys -> Text.Text
+shortResult =
+  \case
+    ProveSuccess -> "success"
+    ProveBug{} -> "likely bug"
+    ProveNoHeuristic{} -> "possible bug"
+    ProveRefine{} -> "refined precondition"
+    ProveCantRefine (Exhausted{}) -> "resource exhausted"
+    ProveCantRefine (Exit (Just code)) -> "exited with " <> tshow code
+    ProveCantRefine (Exit Nothing) -> "exited"
+    ProveCantRefine (MissingFunc (Just nm)) -> "missing function " <> Text.pack nm
+    ProveCantRefine (MissingFunc{}) -> "missing function"
+    ProveCantRefine (MissingSemantics{}) -> "missing semantics"
+    ProveCantRefine (MutableGlobal{}) -> "load from mut global"
+    ProveCantRefine (SolverTimeout{}) -> "solver timeout"
+    ProveCantRefine (SolverUnknown{}) -> "solver unknown"
+    ProveCantRefine (Timeout{}) -> "symex timeout"
+    ProveCantRefine (Unsupported{}) -> "unsupported feature"
 
 -- | Run 'Setup.setup' then 'execAndRefine'. Usually passed to 'refinementLoop'.
 refineOnce ::

--- a/screach/src/Screach/RefineFeature.hs
+++ b/screach/src/Screach/RefineFeature.hs
@@ -165,46 +165,54 @@ refineState bak sla gla refineReplay st config = do
   let rdata = pers ^. GP.personality . GP.pRefinementData
   let memVar = GP.getMemVar pers
   LJ.writeLog gla (GrDiag.RefineDiagnostic (GRDiag.ExecutionResult memVar st))
-  obls <- C.withBackend (C.execResultContext st) $ \bak' ->
-    CB.getProofObligations bak'
-  refResult <- GR.proveAndRefine bak st gla rdata obls
-  trc <- getRecordedTrace st
-  case refResult of
-    GR.ProveSuccess -> do
-      doLog sla RDiag.RefinementSuccess
+  -- Check if execution aborted before trying to prove obligations.
+  -- Without this, aborted paths (e.g., unsupported relocations) are
+  -- silently treated as "success" because there are no proof obligations.
+  case GR.processExecResult st of
+    Just cantRefine -> do
+      doLog sla (RDiag.RefinementPathAborted (GR.shortResult (GR.ProveCantRefine cantRefine)))
       pure C.ExecutionFeatureNoChange
-    GR.ProveCantRefine{} -> do
-      doLog sla RDiag.RefinementCantRefine
-      pure C.ExecutionFeatureNoChange
-    GR.ProveNoHeuristic{} -> do
-      doLog sla RDiag.RefinementNoHeuristic
-      pure C.ExecutionFeatureNoChange
-    GR.ProveBug bi cdata ->
-      let
-        rresultL :: Lens.Lens' (C.ExecResult p sym ext rtp) (Maybe (RefineResult sym ext tys))
-        rresultL = Sched.execResultContextLens . C.cruciblePersonality . refineResult
-        nres = st & rresultL ?~ RefineResult bi cdata trc
-       in
-        pure $
-          C.ExecutionFeatureModifiedState $
-            C.ResultState nres
-    GR.ProveRefine shp -> do
-      let addrWidth = MC.addrWidthRepr (Proxy @w)
-      LJ.writeLog
-        gla
-        ( GrDiag.RefineDiagnostic $
-            GRDiag.RefinementUsingPrecondition addrWidth (GR.refineArgNames rdata) shp
-        )
-      CB.clearProofObligations bak
-      CB.resetAssumptionState bak
-      initSt <- config shp
+    Nothing -> do
+      obls <- C.withBackend (C.execResultContext st) $ \bak' ->
+        CB.getProofObligations bak'
+      refResult <- GR.proveAndRefine bak st gla rdata obls
+      trc <- getRecordedTrace st
+      case refResult of
+        GR.ProveSuccess -> do
+          doLog sla RDiag.RefinementSuccess
+          pure C.ExecutionFeatureNoChange
+        GR.ProveCantRefine _ -> do
+          doLog sla (RDiag.RefinementPathAborted (GR.shortResult refResult))
+          pure C.ExecutionFeatureNoChange
+        GR.ProveNoHeuristic{} -> do
+          doLog sla RDiag.RefinementNoHeuristic
+          pure C.ExecutionFeatureNoChange
+        GR.ProveBug bi cdata ->
+          let
+            rresultL :: Lens.Lens' (C.ExecResult p sym ext rtp) (Maybe (RefineResult sym ext tys))
+            rresultL = Sched.execResultContextLens . C.cruciblePersonality . refineResult
+            nres = st & rresultL ?~ RefineResult bi cdata trc
+           in
+            pure $
+              C.ExecutionFeatureModifiedState $
+                C.ResultState nres
+        GR.ProveRefine shp -> do
+          let addrWidth = MC.addrWidthRepr (Proxy @w)
+          LJ.writeLog
+            gla
+            ( GrDiag.RefineDiagnostic $
+                GRDiag.RefinementUsingPrecondition addrWidth (GR.refineArgNames rdata) shp
+            )
+          CB.clearProofObligations bak
+          CB.resetAssumptionState bak
+          initSt <- config shp
 
-      C.ExecutionFeatureNewState
-        <$> pauseLinearState
-          (CB.backendGetSym bak)
-          initSt
-          trc
-          refineReplay
+          C.ExecutionFeatureNewState
+            <$> pauseLinearState
+              (CB.backendGetSym bak)
+              initSt
+              trc
+              refineReplay
  where
   getRecordedTrace result = do
     -- These panics are impossible. Because we use path splitting, there will

--- a/screach/src/Screach/Run/Diagnostic.hs
+++ b/screach/src/Screach/Run/Diagnostic.hs
@@ -7,6 +7,7 @@ module Screach.Run.Diagnostic (
 ) where
 
 import Data.Macaw.Memory qualified as MM
+import Data.Text (Text)
 import Data.Void (Void, absurd)
 import Grease.Diagnostic.Severity (Severity (Error, Info, Warn))
 import Prettyprinter qualified as PP
@@ -36,6 +37,10 @@ data Diagnostic where
   RefinementCantRefine ::
     Diagnostic
   RefinementStateTimedOut ::
+    Diagnostic
+  RefinementPathAborted ::
+    -- | Short description of why the path was aborted
+    Text ->
     Diagnostic
   RefinementBug ::
     Diagnostic
@@ -82,6 +87,8 @@ instance PP.Pretty Diagnostic where
         failedToReach "Can't refine"
       RefinementStateTimedOut ->
         failedToReach "Can't refine due to timeout"
+      RefinementPathAborted reason ->
+        "Execution path aborted:" PP.<+> PP.pretty reason
       RefinementBug ->
         failedToReach "Found likely bug"
       RefinementResultCount numResults ->
@@ -113,6 +120,7 @@ severity =
     RefinementItersExceeded{} -> Info
     RefinementCantRefine{} -> Info
     RefinementStateTimedOut{} -> Info
+    RefinementPathAborted{} -> Info
     RefinementBug{} -> Info
     RefinementResultCount{} -> Info
     VerifyFailure{} -> Warn

--- a/screach/test-data/aborted-path-log.cbl
+++ b/screach/test-data/aborted-path-log.cbl
@@ -1,0 +1,20 @@
+; Test that aborted paths produce an informative log message.
+
+;; flags {"--entry-symbol", "test"}
+;; flags {"--target-symbol", "vuln"}
+;; flags {"--loop-bound", "5"}
+;; go(prog)
+
+(defun @test ((regs X86Regs)) X86Regs
+  (start start:
+    (jump loop:))
+
+  (defblock loop:
+    (jump loop:)))
+
+(defun @vuln () Unit
+  (start start:
+    (return ())))
+
+;; check "Execution path aborted: resource exhausted"
+;; check "Result count: 0"


### PR DESCRIPTION
I got really confused why something wasn't reachable... until I noticed that the path aborted due to an unsupported relocation.