### PR TITLE
Fix fourmolu configuration in lun.toml

### DIFF
--- a/lun.toml
+++ b/lun.toml
@@ -9,7 +9,7 @@ configs = ["fourmolu.yaml"]
 files = ["*.hs"]
 args = "all"
 check = "fourmolu --mode check"
-cmd = "fourmolu"
+cmd = "fourmolu --mode inplace"
 
 [[tool]]
 name = "hlint"


### PR DESCRIPTION
I couldn't figure out why `lun` wasn't formatting my Haskell files... it's because `fourmolu` without `--mode inplace` just outputs to stdout and exits with 0!