### PR TITLE
Share more setup code between GREASE and Screach

### DIFF
--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -824,17 +824,16 @@ macawRefineOnce ::
   AddressOverrides arch ->
   bak ->
   WE.FloatModeRepr fm ->
-  ArgShapes ext NoTag argTys ->
   H.InitialMem sym ->
   C.GlobalVar CLM.Mem ->
-  [H.RefineHeuristic sym bak ext argTys] ->
+  GRef.RefinementInputs sym bak ext argTys ->
   [CS.ExecutionFeature p sym ext (CS.RegEntry sym ret)] ->
   -- | If simulating a binary, this is 'Just' the address of the user-requested
   -- entrypoint function. Otherwise, this is 'Nothing'.
   Maybe (MC.ArchSegmentOff arch) ->
   EP.EntrypointCfgs (C.SomeCFG ext (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch) ret) ->
   IO (GRef.ProveRefineResult sym ext argTys)
-macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallback setupHook addrOvs bak fm argShapes initMem memVar heuristics execFeats mbCfgAddr entrypointCfgsSsa = do
+macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallback setupHook addrOvs bak fm initMem memVar inputs execFeats mbCfgAddr entrypointCfgsSsa = do
   let argNames = archCtx ^. Arch.archValueNames
       regTypes = archCtx ^. Arch.archRegTypes
   GRef.refineOnce
@@ -845,11 +844,9 @@ macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallbac
     fm
     (macawDataLayout archCtx)
     argNames
-    argNames
     regTypes
-    argShapes
     initMem
-    heuristics
+    inputs
     execFeats
     (macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable execCallback setupHook addrOvs mbCfgAddr entrypointCfgsSsa)
     `X.catches` [ X.Handler $ \(ex :: X86Symbolic.MissingSemantics) ->
@@ -947,7 +944,14 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts execCallback se
         if GO.simNoHeuristics simOpts
           then [H.mustFailHeuristic]
           else H.macawHeuristics la rNames List.++ [H.mustFailHeuristic]
-  result <- GRef.refinementLoop la bounds argNames initArgShapes $ \argShapes ->
+  result <- GRef.refinementLoop la bounds argNames initArgShapes $ \argShapes -> do
+    let inputs =
+          GRef.RefinementInputs
+            { GRef.refineInputArgNames = argNames
+            , GRef.refineInputArgShapes = argShapes
+            , GRef.refineInputHeuristics = heuristics
+            , GRef.refineInputSolver = GO.simSolver simOpts
+            }
     macawRefineOnce
       la
       archCtx
@@ -960,10 +964,9 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts execCallback se
       addrOvs
       bak
       fm
-      argShapes
       initMem
       memVar
-      heuristics
+      inputs
       execFeats
       mbCfgAddr
       entrypointCfgsSsa
@@ -1378,7 +1381,14 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
           if GO.simNoHeuristics simOpts
             then [H.mustFailHeuristic]
             else H.llvmHeuristics la List.++ [H.mustFailHeuristic]
-    GRef.refinementLoop la bounds argNames initArgShapes $ \argShapes ->
+    GRef.refinementLoop la bounds argNames initArgShapes $ \argShapes -> do
+      let inputs =
+            GRef.RefinementInputs
+              { GRef.refineInputArgNames = argNames
+              , GRef.refineInputArgShapes = argShapes
+              , GRef.refineInputHeuristics = heuristics
+              , GRef.refineInputSolver = GO.simSolver simOpts
+              }
       GRef.refineOnce
         la
         simOpts
@@ -1387,11 +1397,9 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
         fm
         dl
         valueNames
-        argNames
         argTys
-        argShapes
         initMem
-        heuristics
+        inputs
         execFeats
         $ \refineData toConc setupMem initFs args -> do
           let llvmPers = GP.mkPersonality memVar dbgCtx toConc refineData

--- a/grease-exe/src/Grease/Main.hs
+++ b/grease-exe/src/Grease/Main.hs
@@ -752,13 +752,16 @@ macawInitState ::
   -- entrypoint function. Otherwise, this is 'Nothing'.
   Maybe (MC.ArchSegmentOff arch) ->
   EP.EntrypointCfgs (C.SomeCFG ext (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch) ret) ->
-  GRef.RefinementData sym bak scope ext argTys wptr ->
-  C.GlobalVar ToConc.ToConcretizeType ->
-  GSetup.SetupMem sym ->
-  GSIO.InitializedFs sym wptr ->
-  GSetup.Args sym ext (Symbolic.MacawCrucibleRegTypes arch) wptr ->
+  GRef.RefinementSetup sym bak scope ext argTys wptr ->
   IO (CS.ExecState p sym ext (CS.RegEntry sym ret))
-macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable execCallback setupHook addrOvs mbCfgAddr entrypointCfgsSsa refineData toConcVar setupMem initFs args = do
+macawInitState la archCtx halloc macawCfgConfig simOpts bak memVar memPtrTable execCallback setupHook addrOvs mbCfgAddr entrypointCfgsSsa setup = do
+  let GRef.RefinementSetup
+        { GRef.setupRefinementData = refineData
+        , GRef.setupToConcretize = toConcVar
+        , GRef.setupSetupMem = setupMem
+        , GRef.setupInitializedFs = initFs
+        , GRef.setupArgs = args
+        } = setup
   let sym = CB.backendGetSym bak
   regs <- liftIO (overrideRegs archCtx sym (GSetup.argVals args))
   EP.EntrypointCfgs
@@ -833,9 +836,7 @@ macawRefineOnce ::
   Maybe (MC.ArchSegmentOff arch) ->
   EP.EntrypointCfgs (C.SomeCFG ext (Ctx.EmptyCtx Ctx.::> Symbolic.ArchRegStruct arch) ret) ->
   IO (GRef.ProveRefineResult sym ext argTys)
-macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallback setupHook addrOvs bak fm initMem memVar inputs execFeats mbCfgAddr entrypointCfgsSsa = do
-  let argNames = archCtx ^. Arch.archValueNames
-      regTypes = archCtx ^. Arch.archRegTypes
+macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallback setupHook addrOvs bak fm initMem memVar inputs execFeats mbCfgAddr entrypointCfgsSsa =
   GRef.refineOnce
     la
     simOpts
@@ -843,8 +844,6 @@ macawRefineOnce la archCtx simOpts halloc macawCfgConfig memPtrTable execCallbac
     bak
     fm
     (macawDataLayout archCtx)
-    argNames
-    regTypes
     initMem
     inputs
     execFeats
@@ -948,6 +947,7 @@ simulateMacawCfg la bak fm halloc macawCfgConfig archCtx simOpts execCallback se
     let inputs =
           GRef.RefinementInputs
             { GRef.refineInputArgNames = argNames
+            , GRef.refineInputArgTypes = regTypes
             , GRef.refineInputArgShapes = argShapes
             , GRef.refineInputHeuristics = heuristics
             , GRef.refineInputSolver = GO.simSolver simOpts
@@ -1373,7 +1373,6 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
   let ?recordLLVMAnnotation = \_ _ _ -> pure ()
   let bounds = GO.simBoundsOpts simOpts
   result <- withMemOptions simOpts $ do
-    let valueNames = Ctx.generate (Ctx.size argTys) (\i -> ValueName ("arg" <> show i))
     let typeCtx = llvmCtx ^. CLT.llvmTypeCtx
     let dl = CLTC.llvmDataLayout typeCtx
     -- See comment above on heuristics in 'simulateMacawCfg'
@@ -1385,6 +1384,7 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
       let inputs =
             GRef.RefinementInputs
               { GRef.refineInputArgNames = argNames
+              , GRef.refineInputArgTypes = argTys
               , GRef.refineInputArgShapes = argShapes
               , GRef.refineInputHeuristics = heuristics
               , GRef.refineInputSolver = GO.simSolver simOpts
@@ -1396,12 +1396,17 @@ simulateLlvmCfg la simOpts bak fm halloc llvmCtx llvmMod initMem setupHook mbSta
         bak
         fm
         dl
-        valueNames
-        argTys
         initMem
         inputs
         execFeats
-        $ \refineData toConc setupMem initFs args -> do
+        $ \setup -> do
+          let GRef.RefinementSetup
+                { GRef.setupRefinementData = refineData
+                , GRef.setupToConcretize = toConc
+                , GRef.setupSetupMem = setupMem
+                , GRef.setupInitializedFs = initFs
+                , GRef.setupArgs = args
+                } = setup
           let llvmPers = GP.mkPersonality memVar dbgCtx toConc refineData
           let p =
                 GLP.mkGreaseLLVMPersonality llvmPers recState repState

--- a/grease/grease.cabal
+++ b/grease/grease.cabal
@@ -261,6 +261,7 @@ library
     Grease.Pretty
     Grease.Refine
     Grease.Refine.Diagnostic
+    Grease.Refine.ErrorCallbacks
     Grease.Refine.RefinementData
     Grease.Scheduler
     Grease.Setup

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -76,6 +76,7 @@ module Grease.Refine (
   refinementLoop,
   buildErrMaps,
   ErrorCallbacks (..),
+  withErrorCallbacks,
   -- The following are used by a downstream project
 
   -- * Implementation details
@@ -90,7 +91,7 @@ import Control.Lens ((^.))
 import Control.Monad qualified as Monad
 import Control.Monad.Except (ExceptT, runExceptT)
 import Control.Monad.IO.Class (MonadIO, liftIO)
-import Data.IORef (IORef, modifyIORef, readIORef)
+import Data.IORef (readIORef)
 import Data.IORef qualified as IORef
 import Data.List qualified as List
 import Data.List.NonEmpty qualified as NE
@@ -105,7 +106,6 @@ import Data.Proxy (Proxy (Proxy))
 import Data.Sequence (Seq)
 import Data.Sequence qualified as Seq
 import Data.Text qualified as Text
-import GHC.IORef (newIORef)
 import Grease.Bug qualified as Bug
 import Grease.Concretize (ConcretizedData)
 import Grease.Concretize qualified as Conc
@@ -113,7 +113,7 @@ import Grease.Concretize.ToConcretize qualified as ToConc
 import Grease.Cursor qualified as Cursor
 import Grease.Cursor.Pointer qualified as PtrCursor
 import Grease.Diagnostic (Diagnostic (RefineDiagnostic), GreaseLogAction)
-import Grease.ErrorDescription (ErrorDescription (CrucibleLLVMError, MacawMemError))
+import Grease.ErrorDescription (ErrorDescription)
 import Grease.ExecutionFeatures (boundedExecFeats)
 import Grease.Heuristic (HeuristicResult (CantRefine, PossibleBug, RefinedPrecondition, Unknown), OnlineSolverAndBackend, RefineHeuristic)
 import Grease.Heuristic.Result (CantRefine (Exhausted, Exit, MissingFunc, MissingSemantics, MutableGlobal, SolverTimeout, SolverUnknown, Timeout, Unsupported))
@@ -121,6 +121,8 @@ import Grease.Options (BoundsOpts)
 import Grease.Options qualified as Opts
 import Grease.Personality qualified as GP
 import Grease.Refine.Diagnostic qualified as Diag
+import Grease.Refine.ErrorCallbacks (ErrorCallbacks (ErrorCallbacks, errorMap, llvmErrCallback, macawAssertionCallback), buildErrMaps, withErrorCallbacks)
+import Grease.Refine.ErrorCallbacks qualified as EC
 import Grease.Refine.RefinementData qualified as RD
 import Grease.Scheduler qualified as Sched
 import Grease.Setup (InitialMem)
@@ -138,9 +140,7 @@ import Lang.Crucible.CFG.Core qualified as C
 import Lang.Crucible.CFG.Extension qualified as C
 import Lang.Crucible.FunctionHandle qualified as C
 import Lang.Crucible.LLVM.DataLayout (DataLayout)
-import Lang.Crucible.LLVM.Errors qualified as CLLVM
 import Lang.Crucible.LLVM.MemModel qualified as CLM
-import Lang.Crucible.LLVM.MemModel.CallStack qualified as LLCS
 import Lang.Crucible.LLVM.MemModel.Partial qualified as Mem
 import Lang.Crucible.Simulator qualified as CS
 import Lang.Crucible.Simulator.RecordAndReplay qualified as CR
@@ -240,41 +240,6 @@ combiner = C.Combiner $ \mr1 mr2 -> do
         ProveSuccess -> pure r1
         ProveNoHeuristic errs2 ->
           pure (failed (ProveNoHeuristic (errs1 <> errs2)))
-
-data ErrorCallbacks sym t
-  = ErrorCallbacks
-  { llvmErrCallback :: LLCS.CallStack -> Mem.BoolAnn sym -> CLLVM.BadBehavior sym -> IO ()
-  , macawAssertionCallback :: sym -> WI.Pred sym -> MSM.MacawError sym -> IO (WI.Pred sym)
-  , errorMap :: IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym))
-  }
-
--- | Builds a mapping from assertions to errors if those assertions are unprovable
---
--- There are two types of errors 'CLLVM.BadBehavior' which
--- describes errors emitted from the llvm memory model/semantics
--- and 'MSM.MacawError' which is emitted from Macaw specific errors.
--- The LLVM callback is intended to be passed to 'recordLLVMAnnotation'
--- and the Macaw callback is intended to be passed to 'processMacawAssert'.
--- In this configuration, Macaw and Crucible-LLVM will record errors
--- to the 'errorMap' as an 'ErrorDescription'
-buildErrMaps ::
-  sym ~ WE.ExprBuilder t st fs =>
-  IO (ErrorCallbacks sym t)
-buildErrMaps = do
-  bbMapRef <- newIORef Map.empty
-  let recordLLVMAnnotation callStack (Mem.BoolAnn ann) bb =
-        modifyIORef bbMapRef $
-          Map.insert ann (CrucibleLLVMError bb callStack)
-  let processMacawAssert sym p err = do
-        (ann, p') <- WI.annotateTerm sym p
-        _ <- modifyIORef bbMapRef $ Map.insert ann (MacawMemError err)
-        pure p'
-  pure
-    ErrorCallbacks
-      { errorMap = bbMapRef
-      , llvmErrCallback = recordLLVMAnnotation
-      , macawAssertionCallback = processMacawAssert
-      }
 
 -- | Look up error information for a goal from its annotations. Not exported.
 lookupErrorInfo ::
@@ -613,34 +578,28 @@ setupRefinement ::
 setupRefinement la fsOpts solverTimeout halloc bak dl valueNames argTys initMem inputs mkResult = do
   let argShapes = RD.refineInputArgShapes inputs
   let sym = CB.backendGetSym bak
-  ErrorCallbacks
-    { errorMap = bbMapRef
-    , llvmErrCallback = recordLLVMAnnotation
-    , macawAssertionCallback = processMacawAssert
-    } <-
-    buildErrMaps
-  let ?recordLLVMAnnotation = recordLLVMAnnotation
-  let ?processMacawAssert = processMacawAssert
-  (args, setupMem, setupAnns) <-
-    Setup.setup la bak dl valueNames argTys argShapes initMem
-  initFs_ <- GSIO.initialLlvmFileSystem halloc sym fsOpts
-  (toConc, globals1) <- liftIO $ ToConc.newToConcretize halloc (GSIO.initFsGlobals initFs_)
-  let initFs = initFs_{GSIO.initFsGlobals = globals1}
-  let concInitState =
-        Conc.InitialState
-          { Conc.initStateArgs = args
-          , Conc.initStateFs = GSIO.initFsContents initFs
-          , Conc.initStateMem = initMem
-          }
-  let refineData =
-        RD.RefinementData
-          { RD.refineInputs = inputs
-          , RD.refineAnns = setupAnns
-          , RD.refineInitState = concInitState
-          , RD.refineSolverTimeout = solverTimeout
-          , RD.refineErrMap = bbMapRef
-          }
-  mkResult refineData toConc setupMem initFs args
+  callbacks <- EC.buildErrMaps
+  EC.withErrorCallbacks callbacks $ do
+    (args, setupMem, setupAnns) <-
+      Setup.setup la bak dl valueNames argTys argShapes initMem
+    initFs_ <- GSIO.initialLlvmFileSystem halloc sym fsOpts
+    (toConc, globals1) <- liftIO $ ToConc.newToConcretize halloc (GSIO.initFsGlobals initFs_)
+    let initFs = initFs_{GSIO.initFsGlobals = globals1}
+    let concInitState =
+          Conc.InitialState
+            { Conc.initStateArgs = args
+            , Conc.initStateFs = GSIO.initFsContents initFs
+            , Conc.initStateMem = initMem
+            }
+    let refineData =
+          RD.RefinementData
+            { RD.refineInputs = inputs
+            , RD.refineAnns = setupAnns
+            , RD.refineInitState = concInitState
+            , RD.refineSolverTimeout = solverTimeout
+            , RD.refineErrMap = EC.errorMap callbacks
+            }
+    mkResult refineData toConc setupMem initFs args
 
 -- | Run 'Setup.setup' then 'execAndRefine'. Usually passed to 'refinementLoop'.
 refineOnce ::

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -70,6 +70,7 @@ module Grease.Refine (
   proveAndRefine,
   ExecData (..),
   refineOnce,
+  setupRefinement,
   execAndRefine,
   RefinementSummary (..),
   refinementLoop,
@@ -287,7 +288,7 @@ lookupErrorInfo ::
   C.SimError ->
   Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym) ->
   IO (Maybe (ErrorDescription sym))
-lookupErrorInfo sym la goalPred simErr bbMap =
+lookupErrorInfo sym la goalPred _simErr bbMap =
   case findPredAnnotations sym goalPred of
     [] -> do
       doLog la Diag.NoAnnotationOnPredicate
@@ -298,30 +299,37 @@ lookupErrorInfo sym la goalPred simErr bbMap =
         pure Nothing
       info -> pure info
 
+-- | Extract the 'GP.Personality' from an 'CS.ExecResult'. Not exported.
+execResultPersonality ::
+  GP.HasPersonality p sym bak t cExt ext ret argTys wptr =>
+  CS.ExecResult p sym ext rtp ->
+  GP.Personality sym bak t cExt ext ret argTys wptr
+execResultPersonality r = CS.execResultContext r ^. CS.cruciblePersonality . GP.personality
+
 -- | How to consume the results of trying to prove a goal. Not exported.
 consumer ::
-  forall p ext r solver sym bak t st argTys w fm.
+  forall p ext ret solver sym bak t st cExt argTys w fm.
   ( C.IsSyntaxExtension ext
   , OnlineSolverAndBackend solver sym bak t st fm
   , 16 C.<= w
   , CLM.HasPtrWidth w
   , ToConc.HasToConcretize p
-  , CR.HasRecordState p p sym ext r
+  , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
+  , GP.HasPersonality p sym bak t cExt ext ret argTys w
   , ?memOpts :: CLM.MemOptions
   , ExtShape ext ~ PtrShape ext w
   ) =>
   bak ->
-  CS.ExecResult p sym ext r ->
+  CS.ExecResult p sym ext (CS.RegEntry sym ret) ->
   GreaseLogAction ->
-  RD.RefinementData sym bak t ext argTys w ->
   C.ProofConsumer sym t (ProveRefineResult sym ext argTys)
-consumer bak execResult la refineData = do
+consumer bak execResult la = do
   let RD.RefinementData
         { RD.refineInputs = inputs
         , RD.refineAnns = anns
         , RD.refineInitState = initState
         , RD.refineErrMap = errMapRef
-        } = refineData
+        } = execResultPersonality execResult ^. GP.pRefinementData
   let RD.RefinementInputs
         { RD.refineInputArgNames = argNames
         , RD.refineInputArgShapes = argShapes
@@ -420,29 +428,30 @@ execCfg bak execData = do
 
 -- | Helper, not exported
 proveAndRefine ::
-  forall p ext r solver sym bak t st argTys w fm.
+  forall p ext ret solver sym bak t st cExt argTys w fm.
   ( C.IsSyntaxExtension ext
   , OnlineSolverAndBackend solver sym bak t st fm
   , 16 C.<= w
   , CLM.HasPtrWidth w
   , ToConc.HasToConcretize p
-  , CR.HasRecordState p p sym ext r
+  , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
+  , GP.HasPersonality p sym bak t cExt ext ret argTys w
   , ?memOpts :: CLM.MemOptions
   , ExtShape ext ~ PtrShape ext w
   ) =>
   bak ->
-  CS.ExecResult p sym ext r ->
+  CS.ExecResult p sym ext (CS.RegEntry sym ret) ->
   GreaseLogAction ->
-  RD.RefinementData sym bak t ext argTys w ->
   CB.ProofObligations sym ->
   IO (ProveRefineResult sym ext argTys)
-proveAndRefine bak execResult la refineData goals = do
+proveAndRefine bak execResult la goals = do
   let sym = CB.backendGetSym bak
+  let refineData = execResultPersonality execResult ^. GP.pRefinementData
   let solver = RD.refineInputSolver (RD.refineInputs refineData)
   let tout = RD.refineSolverTimeout refineData
   let prover = C.offlineProver tout sym W4.defaultLogData (solverAdapter solver)
   let strat = C.ProofStrategy prover combiner
-  let cons = consumer bak execResult la refineData
+  let cons = consumer bak execResult la
   case goals of
     Nothing -> pure ProveSuccess
     Just goals' ->
@@ -475,7 +484,7 @@ processExecResult =
     _ -> Nothing
 
 execAndRefine ::
-  forall ext solver sym bak t st argTys ret w m fm p.
+  forall ext solver sym bak t st cExt argTys ret w m fm p.
   ( MonadIO m
   , C.IsSyntaxExtension ext
   , OnlineSolverAndBackend solver sym bak t st (WE.Flags fm)
@@ -483,17 +492,16 @@ execAndRefine ::
   , CLM.HasPtrWidth w
   , ToConc.HasToConcretize p
   , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
-  , GP.HasMemVar p
+  , GP.HasPersonality p sym bak t cExt ext ret argTys w
   , ?memOpts :: CLM.MemOptions
   , ExtShape ext ~ PtrShape ext w
   ) =>
   bak ->
   W4FM.FloatModeRepr fm ->
   GreaseLogAction ->
-  RD.RefinementData sym bak t ext argTys w ->
   ExecData p sym ext ret ->
   m (ProveRefineResult sym ext argTys)
-execAndRefine bak _fm la refineData execData = do
+execAndRefine bak _fm la execData = do
   let memVar = GP.execStateMemVar (execInitState execData)
   let refineOne initSt = do
         let execData' = execData{execInitState = initSt}
@@ -503,7 +511,7 @@ execAndRefine bak _fm la refineData execData = do
           case processExecResult execResult of
             Just cantRefine -> pure (ProveCantRefine cantRefine)
             Nothing ->
-              proveAndRefine bak execResult la refineData goals
+              proveAndRefine bak execResult la goals
         case execPathStrat execData of
           Opts.Dfs -> do
             loc <- WI.getCurrentProgramLoc (CB.backendGetSym bak)
@@ -567,6 +575,73 @@ shortResult =
     ProveCantRefine (Timeout{}) -> "symex timeout"
     ProveCantRefine (Unsupported{}) -> "unsupported feature"
 
+-- | Set up the initial state for use in 'refineOnce' or trace replay.
+-- Handles error-callback setup, argument allocation, and filesystem
+-- initialization, then delegates to @mkResult@ to produce some result @r@.
+-- Returns the result together with the 'RD.RefinementData' so that callers
+-- which also need to call 'proveAndRefine' (e.g., 'refineOnce') can do so.
+setupRefinement ::
+  ( CLM.HasPtrWidth wptr
+  , C.IsSyntaxExtension ext
+  , CB.IsSymBackend sym bak
+  , sym ~ WE.ExprBuilder t st fs
+  , ?memOpts :: CLM.MemOptions
+  , ExtShape ext ~ PtrShape ext wptr
+  , Cursor.CursorExt ext ~ PtrCursor.Dereference ext wptr
+  ) =>
+  GreaseLogAction ->
+  Opts.FsOpts ->
+  C.Timeout ->
+  C.HandleAllocator ->
+  bak ->
+  DataLayout ->
+  Ctx.Assignment ValueName argTys ->
+  Ctx.Assignment C.TypeRepr argTys ->
+  InitialMem sym ->
+  RD.RefinementInputs sym bak ext argTys ->
+  ( ( MSM.MacawProcessAssertion sym
+    , Mem.HasLLVMAnn sym
+    ) =>
+    RD.RefinementData sym bak t ext argTys wptr ->
+    C.GlobalVar ToConc.ToConcretizeType ->
+    Setup.SetupMem sym ->
+    GSIO.InitializedFs sym wptr ->
+    Setup.Args sym ext argTys wptr ->
+    IO r
+  ) ->
+  IO r
+setupRefinement la fsOpts solverTimeout halloc bak dl valueNames argTys initMem inputs mkResult = do
+  let argShapes = RD.refineInputArgShapes inputs
+  let sym = CB.backendGetSym bak
+  ErrorCallbacks
+    { errorMap = bbMapRef
+    , llvmErrCallback = recordLLVMAnnotation
+    , macawAssertionCallback = processMacawAssert
+    } <-
+    buildErrMaps
+  let ?recordLLVMAnnotation = recordLLVMAnnotation
+  let ?processMacawAssert = processMacawAssert
+  (args, setupMem, setupAnns) <-
+    Setup.setup la bak dl valueNames argTys argShapes initMem
+  initFs_ <- GSIO.initialLlvmFileSystem halloc sym fsOpts
+  (toConc, globals1) <- liftIO $ ToConc.newToConcretize halloc (GSIO.initFsGlobals initFs_)
+  let initFs = initFs_{GSIO.initFsGlobals = globals1}
+  let concInitState =
+        Conc.InitialState
+          { Conc.initStateArgs = args
+          , Conc.initStateFs = GSIO.initFsContents initFs
+          , Conc.initStateMem = initMem
+          }
+  let refineData =
+        RD.RefinementData
+          { RD.refineInputs = inputs
+          , RD.refineAnns = setupAnns
+          , RD.refineInitState = concInitState
+          , RD.refineSolverTimeout = solverTimeout
+          , RD.refineErrMap = bbMapRef
+          }
+  mkResult refineData toConc setupMem initFs args
+
 -- | Run 'Setup.setup' then 'execAndRefine'. Usually passed to 'refinementLoop'.
 refineOnce ::
   ( CLM.HasPtrWidth wptr
@@ -574,7 +649,7 @@ refineOnce ::
   , OnlineSolverAndBackend solver sym bak t st (WE.Flags fm)
   , ToConc.HasToConcretize p
   , CR.HasRecordState p p sym ext (CS.RegEntry sym ret)
-  , GP.HasMemVar p
+  , GP.HasPersonality p sym bak t cExt ext ret argTys wptr
   , ?memOpts :: CLM.MemOptions
   , ExtShape ext ~ PtrShape ext wptr
   , Cursor.CursorExt ext ~ PtrCursor.Dereference ext wptr
@@ -602,38 +677,20 @@ refineOnce ::
   ) ->
   IO (ProveRefineResult sym ext argTys)
 refineOnce la simOpts halloc bak fm dl valueNames argTys initMem inputs execFeats mkInitState = do
-  let RD.RefinementInputs{RD.refineInputArgShapes = argShapes} = inputs
-  let sym = CB.backendGetSym bak
-  ErrorCallbacks
-    { errorMap = bbMapRef
-    , llvmErrCallback = recordLLVMAnnotation
-    , macawAssertionCallback = processMacawAssert
-    } <-
-    buildErrMaps
-  let ?recordLLVMAnnotation = recordLLVMAnnotation
-  let ?processMacawAssert = processMacawAssert
-  (args, setupMem, setupAnns) <-
-    Setup.setup la bak dl valueNames argTys argShapes initMem
-  initFs_ <- GSIO.initialLlvmFileSystem halloc sym (Opts.simFsOpts simOpts)
-  (toConc, globals1) <- liftIO $ ToConc.newToConcretize halloc (GSIO.initFsGlobals initFs_)
-  let initFs = initFs_{GSIO.initFsGlobals = globals1}
-  let concInitState =
-        Conc.InitialState
-          { Conc.initStateArgs = args
-          , Conc.initStateFs = GSIO.initFsContents initFs
-          , Conc.initStateMem = initMem
-          }
-  let boundsOpts = Opts.simBoundsOpts simOpts
-  let refineData =
-        RD.RefinementData
-          { RD.refineInputs = inputs
-          , RD.refineAnns = setupAnns
-          , RD.refineInitState = concInitState
-          , RD.refineSolverTimeout = Opts.simSolverTimeout boundsOpts
-          , RD.refineErrMap = bbMapRef
-          }
-  st <- mkInitState refineData toConc setupMem initFs args
-  boundsFeats_ <- boundedExecFeats boundsOpts
+  st <-
+    setupRefinement
+      la
+      (Opts.simFsOpts simOpts)
+      (Opts.simSolverTimeout (Opts.simBoundsOpts simOpts))
+      halloc
+      bak
+      dl
+      valueNames
+      argTys
+      initMem
+      inputs
+      mkInitState
+  boundsFeats_ <- boundedExecFeats (Opts.simBoundsOpts simOpts)
   let boundsFeats = List.map CS.genericToExecutionFeature boundsFeats_
   let execData =
         ExecData
@@ -641,7 +698,7 @@ refineOnce la simOpts halloc bak fm dl valueNames argTys initMem inputs execFeat
           , execInitState = st
           , execPathStrat = Opts.simPathStrategy simOpts
           }
-  execAndRefine bak fm la refineData execData
+  execAndRefine bak fm la execData
 
 data RefinementSummary sym ext tys
   = RefinementSuccess (ArgShapes ext NoTag tys)

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -71,6 +71,7 @@ module Grease.Refine (
   ExecData (..),
   refineOnce,
   setupRefinement,
+  RefinementSetup (..),
   execAndRefine,
   RefinementSummary (..),
   refinementLoop,
@@ -540,11 +541,26 @@ shortResult =
     ProveCantRefine (Timeout{}) -> "symex timeout"
     ProveCantRefine (Unsupported{}) -> "unsupported feature"
 
+-- | The result of 'setupRefinement': all data needed to build the initial
+-- Crucible exec state and drive refinement.
+data RefinementSetup sym bak t ext argTys wptr
+  = RefinementSetup
+  { setupRefinementData :: RD.RefinementData sym bak t ext argTys wptr
+  , setupToConcretize :: C.GlobalVar ToConc.ToConcretizeType
+  , setupSetupMem :: Setup.SetupMem sym
+  , setupInitializedFs :: GSIO.InitializedFs sym wptr
+  , setupArgs :: Setup.Args sym ext argTys wptr
+  , setupErrorCallbacks :: EC.ErrorCallbacks sym t
+  }
+
 -- | Set up the initial state for use in 'refineOnce' or trace replay.
 -- Handles error-callback setup, argument allocation, and filesystem
--- initialization, then delegates to @mkResult@ to produce some result @r@.
--- Returns the result together with the 'RD.RefinementData' so that callers
--- which also need to call 'proveAndRefine' (e.g., 'refineOnce') can do so.
+-- initialization. Returns a 'RefinementSetup' containing all the data
+-- needed to build the initial Crucible state.
+--
+-- Use 'withErrorCallbacks' with the 'setupErrorCallbacks' field to install
+-- the implicit parameters @?recordLLVMAnnotation@ and @?processMacawAssert@
+-- before creating memory configurations or other objects that capture them.
 setupRefinement ::
   ( CLM.HasPtrWidth wptr
   , C.IsSyntaxExtension ext
@@ -560,23 +576,13 @@ setupRefinement ::
   C.HandleAllocator ->
   bak ->
   DataLayout ->
-  Ctx.Assignment ValueName argTys ->
-  Ctx.Assignment C.TypeRepr argTys ->
   InitialMem sym ->
   RD.RefinementInputs sym bak ext argTys ->
-  ( ( MSM.MacawProcessAssertion sym
-    , Mem.HasLLVMAnn sym
-    ) =>
-    RD.RefinementData sym bak t ext argTys wptr ->
-    C.GlobalVar ToConc.ToConcretizeType ->
-    Setup.SetupMem sym ->
-    GSIO.InitializedFs sym wptr ->
-    Setup.Args sym ext argTys wptr ->
-    IO r
-  ) ->
-  IO r
-setupRefinement la fsOpts solverTimeout halloc bak dl valueNames argTys initMem inputs mkResult = do
+  IO (RefinementSetup sym bak t ext argTys wptr)
+setupRefinement la fsOpts solverTimeout halloc bak dl initMem inputs = do
   let argShapes = RD.refineInputArgShapes inputs
+  let valueNames = RD.refineInputArgNames inputs
+  let argTys = RD.refineInputArgTypes inputs
   let sym = CB.backendGetSym bak
   callbacks <- EC.buildErrMaps
   EC.withErrorCallbacks callbacks $ do
@@ -599,7 +605,15 @@ setupRefinement la fsOpts solverTimeout halloc bak dl valueNames argTys initMem 
             , RD.refineSolverTimeout = solverTimeout
             , RD.refineErrMap = EC.errorMap callbacks
             }
-    mkResult refineData toConc setupMem initFs args
+    pure
+      RefinementSetup
+        { setupRefinementData = refineData
+        , setupToConcretize = toConc
+        , setupSetupMem = setupMem
+        , setupInitializedFs = initFs
+        , setupArgs = args
+        , setupErrorCallbacks = callbacks
+        }
 
 -- | Run 'Setup.setup' then 'execAndRefine'. Usually passed to 'refinementLoop'.
 refineOnce ::
@@ -619,24 +633,18 @@ refineOnce ::
   bak ->
   W4FM.FloatModeRepr fm ->
   DataLayout ->
-  Ctx.Assignment ValueName argTys ->
-  Ctx.Assignment C.TypeRepr argTys ->
   InitialMem sym ->
   RD.RefinementInputs sym bak ext argTys ->
   [CS.ExecutionFeature p sym ext (CS.RegEntry sym ret)] ->
   ( ( MSM.MacawProcessAssertion sym
     , Mem.HasLLVMAnn sym
     ) =>
-    RD.RefinementData sym bak t ext argTys wptr ->
-    C.GlobalVar ToConc.ToConcretizeType ->
-    Setup.SetupMem sym ->
-    GSIO.InitializedFs sym wptr ->
-    Setup.Args sym ext argTys wptr ->
+    RefinementSetup sym bak t ext argTys wptr ->
     IO (CS.ExecState p sym ext (CS.RegEntry sym ret))
   ) ->
   IO (ProveRefineResult sym ext argTys)
-refineOnce la simOpts halloc bak fm dl valueNames argTys initMem inputs execFeats mkInitState = do
-  st <-
+refineOnce la simOpts halloc bak fm dl initMem inputs execFeats mkInitState = do
+  setup <-
     setupRefinement
       la
       (Opts.simFsOpts simOpts)
@@ -644,11 +652,9 @@ refineOnce la simOpts halloc bak fm dl valueNames argTys initMem inputs execFeat
       halloc
       bak
       dl
-      valueNames
-      argTys
       initMem
       inputs
-      mkInitState
+  st <- EC.withErrorCallbacks (setupErrorCallbacks setup) (mkInitState setup)
   boundsFeats_ <- boundedExecFeats (Opts.simBoundsOpts simOpts)
   let boundsFeats = List.map CS.genericToExecutionFeature boundsFeats_
   let execData =

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -317,13 +317,16 @@ consumer ::
   C.ProofConsumer sym t (ProveRefineResult sym ext argTys)
 consumer bak execResult la refineData = do
   let RD.RefinementData
-        { RD.refineAnns = anns
-        , RD.refineArgNames = argNames
-        , RD.refineArgShapes = argShapes
-        , RD.refineHeuristics = heuristics
+        { RD.refineInputs = inputs
+        , RD.refineAnns = anns
         , RD.refineInitState = initState
         , RD.refineErrMap = errMapRef
         } = refineData
+  let RD.RefinementInputs
+        { RD.refineInputArgNames = argNames
+        , RD.refineInputArgShapes = argShapes
+        , RD.refineInputHeuristics = heuristics
+        } = inputs
   C.ProofConsumer $ \goal result -> do
     let sym = CB.backendGetSym bak
     let lp = CB.proofGoal goal
@@ -435,7 +438,7 @@ proveAndRefine ::
   IO (ProveRefineResult sym ext argTys)
 proveAndRefine bak execResult la refineData goals = do
   let sym = CB.backendGetSym bak
-  let solver = RD.refineSolver refineData
+  let solver = RD.refineInputSolver (RD.refineInputs refineData)
   let tout = RD.refineSolverTimeout refineData
   let prover = C.offlineProver tout sym W4.defaultLogData (solverAdapter solver)
   let strat = C.ProofStrategy prover combiner
@@ -624,12 +627,15 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
   let boundsOpts = Opts.simBoundsOpts simOpts
   let refineData =
         RD.RefinementData
-          { RD.refineAnns = setupAnns
-          , RD.refineArgNames = argNames
-          , RD.refineArgShapes = argShapes
-          , RD.refineHeuristics = heuristics
+          { RD.refineInputs =
+              RD.RefinementInputs
+                { RD.refineInputArgNames = argNames
+                , RD.refineInputArgShapes = argShapes
+                , RD.refineInputHeuristics = heuristics
+                , RD.refineInputSolver = Opts.simSolver simOpts
+                }
+          , RD.refineAnns = setupAnns
           , RD.refineInitState = concInitState
-          , RD.refineSolver = Opts.simSolver simOpts
           , RD.refineSolverTimeout = Opts.simSolverTimeout boundsOpts
           , RD.refineErrMap = bbMapRef
           }

--- a/grease/src/Grease/Refine.hs
+++ b/grease/src/Grease/Refine.hs
@@ -586,11 +586,9 @@ refineOnce ::
   W4FM.FloatModeRepr fm ->
   DataLayout ->
   Ctx.Assignment ValueName argTys ->
-  Ctx.Assignment ValueName argTys ->
   Ctx.Assignment C.TypeRepr argTys ->
-  ArgShapes ext NoTag argTys ->
   InitialMem sym ->
-  [RefineHeuristic sym bak ext argTys] ->
+  RD.RefinementInputs sym bak ext argTys ->
   [CS.ExecutionFeature p sym ext (CS.RegEntry sym ret)] ->
   ( ( MSM.MacawProcessAssertion sym
     , Mem.HasLLVMAnn sym
@@ -603,7 +601,8 @@ refineOnce ::
     IO (CS.ExecState p sym ext (CS.RegEntry sym ret))
   ) ->
   IO (ProveRefineResult sym ext argTys)
-refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes initMem heuristics execFeats mkInitState = do
+refineOnce la simOpts halloc bak fm dl valueNames argTys initMem inputs execFeats mkInitState = do
+  let RD.RefinementInputs{RD.refineInputArgShapes = argShapes} = inputs
   let sym = CB.backendGetSym bak
   ErrorCallbacks
     { errorMap = bbMapRef
@@ -627,13 +626,7 @@ refineOnce la simOpts halloc bak fm dl valueNames argNames argTys argShapes init
   let boundsOpts = Opts.simBoundsOpts simOpts
   let refineData =
         RD.RefinementData
-          { RD.refineInputs =
-              RD.RefinementInputs
-                { RD.refineInputArgNames = argNames
-                , RD.refineInputArgShapes = argShapes
-                , RD.refineInputHeuristics = heuristics
-                , RD.refineInputSolver = Opts.simSolver simOpts
-                }
+          { RD.refineInputs = inputs
           , RD.refineAnns = setupAnns
           , RD.refineInitState = concInitState
           , RD.refineSolverTimeout = Opts.simSolverTimeout boundsOpts

--- a/grease/src/Grease/Refine/ErrorCallbacks.hs
+++ b/grease/src/Grease/Refine/ErrorCallbacks.hs
@@ -1,0 +1,83 @@
+{-# LANGUAGE ImplicitParams #-}
+{-# LANGUAGE RankNTypes #-}
+
+-- |
+-- Copyright   : (c) Galois, Inc. 2027
+-- Maintainer  : GREASE Maintainers <grease@galois.com>
+-- Module      : Grease.Refine.ErrorCallbacks
+-- Description : Error callbacks for refinement
+module Grease.Refine.ErrorCallbacks (
+  ErrorCallbacks (..),
+  buildErrMaps,
+  withErrorCallbacks,
+) where
+
+import Data.IORef (IORef, modifyIORef)
+import Data.Macaw.Symbolic.Memory qualified as MSM
+import Data.Map.Strict qualified as Map
+import Data.Parameterized.Nonce (Nonce)
+import GHC.IORef (newIORef)
+import Grease.ErrorDescription (ErrorDescription (CrucibleLLVMError, MacawMemError))
+import Lang.Crucible.CFG.Core qualified as C
+import Lang.Crucible.LLVM.Errors qualified as CLLVM
+import Lang.Crucible.LLVM.MemModel qualified as CLM
+import Lang.Crucible.LLVM.MemModel.CallStack qualified as LLCS
+import Lang.Crucible.LLVM.MemModel.Partial qualified as Mem
+import What4.Expr qualified as WE
+import What4.Interface qualified as WI
+
+-- | Callbacks that record error information during symbolic execution.
+--
+-- Type parameters:
+--
+-- - @sym@: instance of 'Lang.Crucible.Backend.IsSymInterface'
+-- - @t@: nonce generator scope
+data ErrorCallbacks sym t
+  = ErrorCallbacks
+  { llvmErrCallback :: LLCS.CallStack -> Mem.BoolAnn sym -> CLLVM.BadBehavior sym -> IO ()
+  -- ^ Callback to pass to @recordLLVMAnnotation@
+  , macawAssertionCallback :: sym -> WI.Pred sym -> MSM.MacawError sym -> IO (WI.Pred sym)
+  -- ^ Callback to pass to @processMacawAssert@
+  , errorMap :: IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym))
+  -- ^ Map populated by the callbacks above, keyed by the annotation nonce
+  }
+
+-- | Build an 'ErrorCallbacks' that records memory errors into a fresh map.
+--
+-- There are two types of errors: 'CLLVM.BadBehavior' (from the LLVM memory
+-- model/semantics) and 'MSM.MacawError' (Macaw-specific errors). Pass
+-- 'llvmErrCallback' to @recordLLVMAnnotation@ and 'macawAssertionCallback'
+-- to @processMacawAssert@.
+buildErrMaps ::
+  sym ~ WE.ExprBuilder t st fs =>
+  IO (ErrorCallbacks sym t)
+buildErrMaps = do
+  bbMapRef <- newIORef Map.empty
+  let recordLLVMAnnotation callStack (Mem.BoolAnn ann) bb =
+        modifyIORef bbMapRef $
+          Map.insert ann (CrucibleLLVMError bb callStack)
+  let processMacawAssert sym p err = do
+        (ann, p') <- WI.annotateTerm sym p
+        _ <- modifyIORef bbMapRef $ Map.insert ann (MacawMemError err)
+        pure p'
+  pure
+    ErrorCallbacks
+      { errorMap = bbMapRef
+      , llvmErrCallback = recordLLVMAnnotation
+      , macawAssertionCallback = processMacawAssert
+      }
+
+-- | Establish the implicit parameters @?recordLLVMAnnotation@ and
+-- @?processMacawAssert@ from an 'ErrorCallbacks' value, then run @action@.
+withErrorCallbacks ::
+  ErrorCallbacks sym t ->
+  ( ( MSM.MacawProcessAssertion sym
+    , CLM.HasLLVMAnn sym
+    ) =>
+    IO r
+  ) ->
+  IO r
+withErrorCallbacks ErrorCallbacks{llvmErrCallback, macawAssertionCallback} action =
+  let ?recordLLVMAnnotation = llvmErrCallback
+      ?processMacawAssert = macawAssertionCallback
+   in action

--- a/grease/src/Grease/Refine/RefinementData.hs
+++ b/grease/src/Grease/Refine/RefinementData.hs
@@ -5,8 +5,9 @@
 -- Copyright        : (c) Galois, Inc. 2026
 -- Maintainer       : GREASE Maintainers <grease@galois.com>
 --
--- The 'RefinementData' type.
+-- The 'RefinementData' and 'RefinementInputs' types.
 module Grease.Refine.RefinementData (
+  RefinementInputs (..),
   RefinementData (..),
 ) where
 
@@ -27,6 +28,28 @@ import Grease.ValueName (ValueName)
 import Lang.Crucible.Types qualified as C
 import Lang.Crucible.Utils.Timeout qualified as C
 
+-- | The caller-provided inputs to the refinement process: the things that are
+-- known up-front and drive how refinement behaves.
+--
+-- Type parameters:
+--
+-- - @sym@: the symbolic backend expression type
+-- - @bak@: the symbolic backend type
+-- - @ext@: the Crucible language extension
+-- - @argTys@: Crucible argument types for the target function
+type RefinementInputs :: Type -> Type -> Type -> Ctx.Ctx C.CrucibleType -> Type
+data RefinementInputs sym bak ext argTys
+  = RefinementInputs
+  { refineInputArgNames :: Ctx.Assignment ValueName argTys
+  -- ^ Names of the function arguments.
+  , refineInputArgShapes :: ArgShapes ext NoTag argTys
+  -- ^ Current argument shapes being refined.
+  , refineInputHeuristics :: [RefineHeuristic sym bak ext argTys]
+  -- ^ Heuristics used to guide refinement.
+  , refineInputSolver :: Solver
+  -- ^ The solver to use for discharging proof obligations.
+  }
+
 -- | Data needed for refinement.
 --
 -- Type parameters:
@@ -40,12 +63,9 @@ import Lang.Crucible.Utils.Timeout qualified as C
 type RefinementData :: Type -> Type -> Type -> Type -> Ctx.Ctx C.CrucibleType -> Natural -> Type
 data RefinementData sym bak t ext argTys wptr
   = RefinementData
-  { refineAnns :: Anns.Annotations sym ext argTys
-  , refineArgNames :: Ctx.Assignment ValueName argTys
-  , refineArgShapes :: ArgShapes ext NoTag argTys
-  , refineHeuristics :: [RefineHeuristic sym bak ext argTys]
+  { refineInputs :: RefinementInputs sym bak ext argTys
+  , refineAnns :: Anns.Annotations sym ext argTys
   , refineInitState :: Conc.InitialState sym ext argTys wptr
-  , refineSolver :: Solver
   , refineSolverTimeout :: C.Timeout
   , refineErrMap :: IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym))
   }

--- a/grease/src/Grease/Refine/RefinementData.hs
+++ b/grease/src/Grease/Refine/RefinementData.hs
@@ -25,7 +25,7 @@ import Grease.Shape (ArgShapes)
 import Grease.Shape.NoTag (NoTag)
 import Grease.Solver (Solver)
 import Grease.ValueName (ValueName)
-import Lang.Crucible.Types qualified as C
+import Lang.Crucible.Types qualified as CT
 import Lang.Crucible.Utils.Timeout qualified as C
 
 -- | The caller-provided inputs to the refinement process: the things that are
@@ -37,11 +37,13 @@ import Lang.Crucible.Utils.Timeout qualified as C
 -- - @bak@: the symbolic backend type
 -- - @ext@: the Crucible language extension
 -- - @argTys@: Crucible argument types for the target function
-type RefinementInputs :: Type -> Type -> Type -> Ctx.Ctx C.CrucibleType -> Type
+type RefinementInputs :: Type -> Type -> Type -> Ctx.Ctx CT.CrucibleType -> Type
 data RefinementInputs sym bak ext argTys
   = RefinementInputs
   { refineInputArgNames :: Ctx.Assignment ValueName argTys
   -- ^ Names of the function arguments.
+  , refineInputArgTypes :: Ctx.Assignment CT.TypeRepr argTys
+  -- ^ Crucible type representations of the function arguments.
   , refineInputArgShapes :: ArgShapes ext NoTag argTys
   -- ^ Current argument shapes being refined.
   , refineInputHeuristics :: [RefineHeuristic sym bak ext argTys]
@@ -60,12 +62,12 @@ data RefinementInputs sym bak ext argTys
 -- - @ext@: the Crucible language extension
 -- - @argTys@: Crucible argument types for the target function
 -- - @wptr@: pointer width
-type RefinementData :: Type -> Type -> Type -> Type -> Ctx.Ctx C.CrucibleType -> Natural -> Type
+type RefinementData :: Type -> Type -> Type -> Type -> Ctx.Ctx CT.CrucibleType -> Natural -> Type
 data RefinementData sym bak t ext argTys wptr
   = RefinementData
   { refineInputs :: RefinementInputs sym bak ext argTys
   , refineAnns :: Anns.Annotations sym ext argTys
   , refineInitState :: Conc.InitialState sym ext argTys wptr
   , refineSolverTimeout :: C.Timeout
-  , refineErrMap :: IORef (Map.Map (Nonce t C.BaseBoolType) (ErrorDescription sym))
+  , refineErrMap :: IORef (Map.Map (Nonce t CT.BaseBoolType) (ErrorDescription sym))
   }

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -994,68 +994,88 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
         let inputs =
               GR.RefinementInputs
                 { GR.refineInputArgNames = argNames
+                , GR.refineInputArgTypes = regTypes
                 , GR.refineInputArgShapes = argShapes
                 , GR.refineInputHeuristics = heuristics
                 , GR.refineInputSolver = Conf.solver conf
                 }
-        GR.setupRefinement
-          gla
-          (Conf.fsOpts conf)
-          (GO.simSolverTimeout boundsOpts)
-          halloc
-          bak
-          dataLayout
-          argNames
-          regTypes
-          initMem
-          inputs
-          ( \refineData toConc setupMem initFs args -> do
-              let memCfg0 = GM.memConfigInitial bak archCtx ptrTable skipRelocs relocs
-              let sym = CB.backendGetSym bak
-              let fs = GSIO.initFs initFs
-                  globals1 = GSIO.initFsGlobals initFs
-                  initFsOv = GSIO.initFsOverride initFs
-              let userOvPaths = Conf.overrides conf
-              let ovs =
-                    SF.customScreachOverrides sla
-                      <> builtinStubsOverrides
-                        memVar
-                        memCfg0
-                        fs
-                        (archCtx ^. Arch.archInfo . to MAI.archEndianness)
-              fnOvsMap <- liftIO $ do
-                result <- GMO.mkMacawOverrideMap bak ovs userOvPaths halloc archCtx
-                let usrErr = userError sla . PP.pretty
-                case result of
-                  -- See Note [Explicitly listed errors]
-                  Left (GMOS.MacawSExpOverrideParseError e@Syntax.SExpressionParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
-                  Left (GMOS.MacawSExpOverrideParseError e@Syntax.SyntaxParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
-                  Left e@GMOS.MacawSExpOverrideLoaderError{} -> usrErr e
-                  Right m -> pure m
-              fnAddrOvs <-
-                liftIO (Syntax.loadOverridesYaml loadOpts mem (Map.keysSet fnOvsMap) (Conf.overridesYaml conf))
-                  >>= \case
-                    -- See Note [Explicitly listed errors]
-                    Left e@Syntax.LoadOverridesYamlParseError{} -> userError sla (PP.pretty e)
-                    Left e@Syntax.LoadOverridesYamlResolveError{} -> userError sla (PP.pretty e)
-                    Right ok -> pure ok
-              let cOpts = Conf.callOpts conf
-              let defaultLfhd =
-                    ResolveCall.defaultLookupFunctionHandleDispatch
-                      bak
-                      gla
-                      halloc
-                      archCtx
-                      mem
-                      fnOvsMap
-                      (overrideError sla)
-              let lfhd
-                    | isEcfs =
-                        ecfsLookupFunctionHandleDispatch gla halloc archCtx binMd mem defaultLfhd
-                    | otherwise =
-                        defaultLfhd
-              let memCfg =
-                    ( GM.memConfigWithHandles
+        setup <-
+          GR.setupRefinement
+            gla
+            (Conf.fsOpts conf)
+            (GO.simSolverTimeout boundsOpts)
+            halloc
+            bak
+            dataLayout
+            initMem
+            inputs
+        GR.withErrorCallbacks (GR.setupErrorCallbacks setup) $ do
+          let refineData = GR.setupRefinementData setup
+              toConc = GR.setupToConcretize setup
+              setupMem = GR.setupSetupMem setup
+              initFs = GR.setupInitializedFs setup
+              args = GR.setupArgs setup
+          let memCfg0 = GM.memConfigInitial bak archCtx ptrTable skipRelocs relocs
+          let sym = CB.backendGetSym bak
+          let fs = GSIO.initFs initFs
+              globals1 = GSIO.initFsGlobals initFs
+              initFsOv = GSIO.initFsOverride initFs
+          let userOvPaths = Conf.overrides conf
+          let ovs =
+                SF.customScreachOverrides sla
+                  <> builtinStubsOverrides
+                    memVar
+                    memCfg0
+                    fs
+                    (archCtx ^. Arch.archInfo . to MAI.archEndianness)
+          fnOvsMap <- liftIO $ do
+            result <- GMO.mkMacawOverrideMap bak ovs userOvPaths halloc archCtx
+            let usrErr = userError sla . PP.pretty
+            case result of
+              -- See Note [Explicitly listed errors]
+              Left (GMOS.MacawSExpOverrideParseError e@Syntax.SExpressionParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
+              Left (GMOS.MacawSExpOverrideParseError e@Syntax.SyntaxParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
+              Left e@GMOS.MacawSExpOverrideLoaderError{} -> usrErr e
+              Right m -> pure m
+          fnAddrOvs <-
+            liftIO (Syntax.loadOverridesYaml loadOpts mem (Map.keysSet fnOvsMap) (Conf.overridesYaml conf))
+              >>= \case
+                -- See Note [Explicitly listed errors]
+                Left e@Syntax.LoadOverridesYamlParseError{} -> userError sla (PP.pretty e)
+                Left e@Syntax.LoadOverridesYamlResolveError{} -> userError sla (PP.pretty e)
+                Right ok -> pure ok
+          let cOpts = Conf.callOpts conf
+          let defaultLfhd =
+                ResolveCall.defaultLookupFunctionHandleDispatch
+                  bak
+                  gla
+                  halloc
+                  archCtx
+                  mem
+                  fnOvsMap
+                  (overrideError sla)
+          let lfhd
+                | isEcfs =
+                    ecfsLookupFunctionHandleDispatch gla halloc archCtx binMd mem defaultLfhd
+                | otherwise =
+                    defaultLfhd
+          let memCfg =
+                ( GM.memConfigWithHandles
+                    bak
+                    gla
+                    halloc
+                    archCtx
+                    binMd
+                    mem
+                    fnOvsMap
+                    fnAddrOvs
+                    builtinGenericSyscalls
+                    cOpts
+                    (overrideError sla)
+                    memCfg0
+                )
+                  { MS.lookupFunctionHandle =
+                      ResolveCall.lookupFunctionHandle
                         bak
                         gla
                         halloc
@@ -1064,69 +1084,53 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
                         mem
                         fnOvsMap
                         fnAddrOvs
-                        builtinGenericSyscalls
                         cOpts
-                        (overrideError sla)
-                        memCfg0
-                    )
-                      { MS.lookupFunctionHandle =
-                          ResolveCall.lookupFunctionHandle
-                            bak
-                            gla
-                            halloc
-                            archCtx
-                            binMd
-                            mem
-                            fnOvsMap
-                            fnAddrOvs
-                            cOpts
-                            lfhd
-                      }
-              evalFn <- MS.withArchEval @MS.LLVMMemory @MX86.X86_64 (archCtx ^. Arch.archVals) sym pure
-              let macawExtImpl = MS.macawExtensions evalFn memVar memCfg
-              let extImpl =
-                    -- We omit the goal evaluator in the case that we have a target
-                    -- override because the target override determines when we have
-                    -- truly reached the goal (by calling the `@reached` built-in).
-                    case mbTargetAddr of
-                      Just targetAddr
-                        | Nothing <- Conf.targetOverride conf ->
-                            GE.goalEvaluatorMacawExtension macawExtImpl sla bak mem rtLoc targetAddr
-                      _ ->
-                        macawExtImpl
-              let dbgOpts = Conf.debugOpts conf
-              let dbgCmdExt = MDebug.macawCommandExt (archCtx ^. Arch.archVals)
-              dbgCtx <- initDebugger sla dbgOpts dbgCmdExt (archCtx ^. Arch.archRegStructType)
-              gssRecState <- RR.mkRecordState halloc
-              gssEmpTrace <- RR.emptyRecordedTrace sym
-              gssRepState <- RR.mkReplayState halloc gssEmpTrace
-              let gssPers = GP.mkPersonality memVar dbgCtx toConc refineData
-              let greaseSimState =
-                    GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
-                      & GMSS.discoveredFnHandles .~ discoveredHdls
-              personality <-
-                SP.mkScreachSimulatorState
-                  sym
-                  halloc
-                  greaseSimState
-              GM.initState
-                bak
-                gla
-                extImpl
-                execAction
-                halloc
-                setupMem
-                globals1
-                initFsOv
-                archCtx
-                setupHook
-                addrOvs
-                personality
-                (GS.argVals args)
-                fnOvsMap
-                mbStartupOvSomeSsaCfg
-                (CCC.SomeCFG entryRegSsaCfg)
-          )
+                        lfhd
+                  }
+          evalFn <- MS.withArchEval @MS.LLVMMemory @MX86.X86_64 (archCtx ^. Arch.archVals) sym pure
+          let macawExtImpl = MS.macawExtensions evalFn memVar memCfg
+          let extImpl =
+                -- We omit the goal evaluator in the case that we have a target
+                -- override because the target override determines when we have
+                -- truly reached the goal (by calling the `@reached` built-in).
+                case mbTargetAddr of
+                  Just targetAddr
+                    | Nothing <- Conf.targetOverride conf ->
+                        GE.goalEvaluatorMacawExtension macawExtImpl sla bak mem rtLoc targetAddr
+                  _ ->
+                    macawExtImpl
+          let dbgOpts = Conf.debugOpts conf
+          let dbgCmdExt = MDebug.macawCommandExt (archCtx ^. Arch.archVals)
+          dbgCtx <- initDebugger sla dbgOpts dbgCmdExt (archCtx ^. Arch.archRegStructType)
+          gssRecState <- RR.mkRecordState halloc
+          gssEmpTrace <- RR.emptyRecordedTrace sym
+          gssRepState <- RR.mkReplayState halloc gssEmpTrace
+          let gssPers = GP.mkPersonality memVar dbgCtx toConc refineData
+          let greaseSimState =
+                GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
+                  & GMSS.discoveredFnHandles .~ discoveredHdls
+          personality <-
+            SP.mkScreachSimulatorState
+              sym
+              halloc
+              greaseSimState
+          GM.initState
+            bak
+            gla
+            extImpl
+            execAction
+            halloc
+            setupMem
+            globals1
+            initFsOv
+            archCtx
+            setupHook
+            addrOvs
+            personality
+            (GS.argVals args)
+            fnOvsMap
+            mbStartupOvSomeSsaCfg
+            (CCC.SomeCFG entryRegSsaCfg)
 
 withMaybeFile :: Maybe FilePath -> IOMode -> (Maybe Handle -> IO a) -> IO a
 withMaybeFile Nothing _ f = f Nothing

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -1101,12 +1101,15 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
 
         let refineData =
               GR.RefinementData
-                { GR.refineAnns = setupAnns
-                , GR.refineArgNames = argNames
-                , GR.refineArgShapes = argShapes
-                , GR.refineHeuristics = heuristics
+                { GR.refineInputs =
+                    GR.RefinementInputs
+                      { GR.refineInputArgNames = argNames
+                      , GR.refineInputArgShapes = argShapes
+                      , GR.refineInputHeuristics = heuristics
+                      , GR.refineInputSolver = Conf.solver conf
+                      }
+                , GR.refineAnns = setupAnns
                 , GR.refineInitState = concInitState
-                , GR.refineSolver = Conf.solver conf
                 , GR.refineSolverTimeout = GO.simSolverTimeout boundsOpts
                 , GR.refineErrMap = bbMapRef
                 }

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -956,25 +956,13 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
             argNames = archCtx ^. Arch.archValueNames
             regTypes = archCtx ^. Arch.archRegTypes
         let loadOpts = GL.binLoadOptions binMd
-            symMap = GL.binSymMap binMd
-            pltStubs = GL.binPltStubs binMd
-            dynFunMap = GL.binDynFunMap binMd
             relocs = GL.binRelocs binMd
-        let sym = CB.backendGetSym bak
-        GR.ErrorCallbacks
-          { GR.errorMap = bbMapRef
-          , GR.llvmErrCallback = recordLLVMAnnotation
-          , GR.macawAssertionCallback = processMacawAssert
-          } <-
-          GR.buildErrMaps
-
         let addrWidth = MC.addrWidthRepr (Proxy @64)
         LJ.writeLog
           gla
           (GD.RefineDiagnostic (RDiag.RefinementUsingPrecondition addrWidth argNames argShapes))
-        let ?recordLLVMAnnotation = recordLLVMAnnotation
-        let ?processMacawAssert = processMacawAssert
-        (initMem, memCfg0) <- do
+        (initMem, ptrTable) <- do
+          let ?recordLLVMAnnotation = \_ _ _ -> pure ()
           memModelContents <-
             case Conf.globals conf of
               GO.Initialized -> pure MSML.ConcreteMutable
@@ -988,98 +976,8 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
               mem
               memModelContents
               relocs
-          let skipRelocs = GO.SkipUnsupportedRelocs False
-          let memCfg = GM.memConfigInitial bak archCtx ptrTable skipRelocs relocs
-          pure (mem0, memCfg)
-        (args, setupMem, setupAnns) <- GS.setup gla bak dataLayout argNames regTypes argShapes initMem
-        -- TODO: When adding support for AArch32 and PPC, override the link
-        -- registers like GREASE does, probably should refactor that in GREASE
-        -- to make it easier to use here - part of ArchCtx?
-
-        -- Initialize the file system
-        GSIO.InitializedFs fileContents fs globals0 initFsOv <-
-          liftIO $ GSIO.initialLlvmFileSystem halloc sym (Conf.fsOpts conf)
-
-        let userOvPaths = Conf.overrides conf
-        let ovs =
-              SF.customScreachOverrides sla
-                <> builtinStubsOverrides
-                  memVar
-                  memCfg0
-                  fs
-                  (archCtx ^. Arch.archInfo . to MAI.archEndianness)
-        fnOvsMap <- liftIO $ do
-          result <- GMO.mkMacawOverrideMap bak ovs userOvPaths halloc archCtx
-          let usrErr = userError sla . PP.pretty
-          case result of
-            -- See Note [Explicitly listed errors]
-            Left (GMOS.MacawSExpOverrideParseError e@Syntax.SExpressionParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
-            Left (GMOS.MacawSExpOverrideParseError e@Syntax.SyntaxParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
-            Left e@GMOS.MacawSExpOverrideLoaderError{} -> usrErr e
-            Right m -> pure m
-        fnAddrOvs <-
-          liftIO (Syntax.loadOverridesYaml loadOpts mem (Map.keysSet fnOvsMap) (Conf.overridesYaml conf))
-            >>= \case
-              -- See Note [Explicitly listed errors]
-              Left e@Syntax.LoadOverridesYamlParseError{} -> userError sla (PP.pretty e)
-              Left e@Syntax.LoadOverridesYamlResolveError{} -> userError sla (PP.pretty e)
-              Right ok -> pure ok
-        let cOpts = Conf.callOpts conf
-        let defaultLfhd =
-              ResolveCall.defaultLookupFunctionHandleDispatch
-                bak
-                gla
-                halloc
-                archCtx
-                mem
-                fnOvsMap
-                (overrideError sla)
-        let lfhd
-              | isEcfs =
-                  ecfsLookupFunctionHandleDispatch gla halloc archCtx binMd mem defaultLfhd
-              | otherwise =
-                  defaultLfhd
-        let memCfg =
-              ( GM.memConfigWithHandles
-                  bak
-                  gla
-                  halloc
-                  archCtx
-                  binMd
-                  mem
-                  fnOvsMap
-                  fnAddrOvs
-                  builtinGenericSyscalls
-                  cOpts
-                  (overrideError sla)
-                  memCfg0
-              )
-                { MS.lookupFunctionHandle =
-                    ResolveCall.lookupFunctionHandle
-                      bak
-                      gla
-                      halloc
-                      archCtx
-                      binMd
-                      mem
-                      fnOvsMap
-                      fnAddrOvs
-                      cOpts
-                      lfhd
-                }
-        evalFn <- MS.withArchEval @MS.LLVMMemory @MX86.X86_64 (archCtx ^. Arch.archVals) sym pure
-        let macawExtImpl = MS.macawExtensions evalFn memVar memCfg
-        let extImpl =
-              -- We omit the goal evaluator in the case that we have a target
-              -- override because the target override determines when we have
-              -- truly reached the goal (by calling the `@reached` built-in).
-              case mbTargetAddr of
-                Just targetAddr
-                  | Nothing <- Conf.targetOverride conf ->
-                      GE.goalEvaluatorMacawExtension macawExtImpl sla bak mem rtLoc targetAddr
-                _ ->
-                  macawExtImpl
-        (toConcVar, globals1) <- liftIO $ ToConc.newToConcretize halloc globals0
+          pure (mem0, ptrTable)
+        let skipRelocs = GO.SkipUnsupportedRelocs False
         -- NB: We intentionally exclude `mustFailHeuristics` here. This is
         -- primarily because must-fail would incorrectly deem targets that are
         -- always reachable in all paths as refinement failures. Note that
@@ -1087,64 +985,148 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
         -- a bug-finding mechanism), so it shouldn't impact screach's
         -- reachability results.
         let heuristics =
-              reachedHeuristic
-                : if Conf.noHeuristics conf
-                  then []
-                  else GH.macawHeuristics gla rNames
-        let concInitState =
-              Conc.InitialState
-                { Conc.initStateArgs = args
-                , Conc.initStateFs = fileContents
-                , Conc.initStateMem = initMem
-                }
+              let ?recordLLVMAnnotation = \_ _ _ -> pure ()
+               in reachedHeuristic
+                    : if Conf.noHeuristics conf
+                      then []
+                      else GH.macawHeuristics gla rNames
         let boundsOpts = Conf.boundsOpts conf
-
-        let refineData =
-              GR.RefinementData
-                { GR.refineInputs =
-                    GR.RefinementInputs
-                      { GR.refineInputArgNames = argNames
-                      , GR.refineInputArgShapes = argShapes
-                      , GR.refineInputHeuristics = heuristics
-                      , GR.refineInputSolver = Conf.solver conf
-                      }
-                , GR.refineAnns = setupAnns
-                , GR.refineInitState = concInitState
-                , GR.refineSolverTimeout = GO.simSolverTimeout boundsOpts
-                , GR.refineErrMap = bbMapRef
+        let inputs =
+              GR.RefinementInputs
+                { GR.refineInputArgNames = argNames
+                , GR.refineInputArgShapes = argShapes
+                , GR.refineInputHeuristics = heuristics
+                , GR.refineInputSolver = Conf.solver conf
                 }
-        let dbgOpts = Conf.debugOpts conf
-        let dbgCmdExt = MDebug.macawCommandExt (archCtx ^. Arch.archVals)
-        dbgCtx <- initDebugger sla dbgOpts dbgCmdExt (archCtx ^. Arch.archRegStructType)
-        gssRecState <- RR.mkRecordState halloc
-        gssEmpTrace <- RR.emptyRecordedTrace sym
-        gssRepState <- RR.mkReplayState halloc gssEmpTrace
-        let gssPers = GP.mkPersonality memVar dbgCtx toConcVar refineData
-        let greaseSimState =
-              GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
-                & GMSS.discoveredFnHandles .~ discoveredHdls
-        personality <-
-          SP.mkScreachSimulatorState
-            sym
-            halloc
-            greaseSimState
-        GM.initState
-          bak
+        GR.setupRefinement
           gla
-          extImpl
-          execAction
+          (Conf.fsOpts conf)
+          (GO.simSolverTimeout boundsOpts)
           halloc
-          setupMem
-          globals1
-          initFsOv
-          archCtx
-          setupHook
-          addrOvs
-          personality
-          (GS.argVals args)
-          fnOvsMap
-          mbStartupOvSomeSsaCfg
-          (CCC.SomeCFG entryRegSsaCfg)
+          bak
+          dataLayout
+          argNames
+          regTypes
+          initMem
+          inputs
+          ( \refineData toConc setupMem initFs args -> do
+              let memCfg0 = GM.memConfigInitial bak archCtx ptrTable skipRelocs relocs
+              let sym = CB.backendGetSym bak
+              let fs = GSIO.initFs initFs
+                  globals1 = GSIO.initFsGlobals initFs
+                  initFsOv = GSIO.initFsOverride initFs
+              let userOvPaths = Conf.overrides conf
+              let ovs =
+                    SF.customScreachOverrides sla
+                      <> builtinStubsOverrides
+                        memVar
+                        memCfg0
+                        fs
+                        (archCtx ^. Arch.archInfo . to MAI.archEndianness)
+              fnOvsMap <- liftIO $ do
+                result <- GMO.mkMacawOverrideMap bak ovs userOvPaths halloc archCtx
+                let usrErr = userError sla . PP.pretty
+                case result of
+                  -- See Note [Explicitly listed errors]
+                  Left (GMOS.MacawSExpOverrideParseError e@Syntax.SExpressionParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
+                  Left (GMOS.MacawSExpOverrideParseError e@Syntax.SyntaxParseError{}) -> usrErr (GMOS.MacawSExpOverrideParseError e)
+                  Left e@GMOS.MacawSExpOverrideLoaderError{} -> usrErr e
+                  Right m -> pure m
+              fnAddrOvs <-
+                liftIO (Syntax.loadOverridesYaml loadOpts mem (Map.keysSet fnOvsMap) (Conf.overridesYaml conf))
+                  >>= \case
+                    -- See Note [Explicitly listed errors]
+                    Left e@Syntax.LoadOverridesYamlParseError{} -> userError sla (PP.pretty e)
+                    Left e@Syntax.LoadOverridesYamlResolveError{} -> userError sla (PP.pretty e)
+                    Right ok -> pure ok
+              let cOpts = Conf.callOpts conf
+              let defaultLfhd =
+                    ResolveCall.defaultLookupFunctionHandleDispatch
+                      bak
+                      gla
+                      halloc
+                      archCtx
+                      mem
+                      fnOvsMap
+                      (overrideError sla)
+              let lfhd
+                    | isEcfs =
+                        ecfsLookupFunctionHandleDispatch gla halloc archCtx binMd mem defaultLfhd
+                    | otherwise =
+                        defaultLfhd
+              let memCfg =
+                    ( GM.memConfigWithHandles
+                        bak
+                        gla
+                        halloc
+                        archCtx
+                        binMd
+                        mem
+                        fnOvsMap
+                        fnAddrOvs
+                        builtinGenericSyscalls
+                        cOpts
+                        (overrideError sla)
+                        memCfg0
+                    )
+                      { MS.lookupFunctionHandle =
+                          ResolveCall.lookupFunctionHandle
+                            bak
+                            gla
+                            halloc
+                            archCtx
+                            binMd
+                            mem
+                            fnOvsMap
+                            fnAddrOvs
+                            cOpts
+                            lfhd
+                      }
+              evalFn <- MS.withArchEval @MS.LLVMMemory @MX86.X86_64 (archCtx ^. Arch.archVals) sym pure
+              let macawExtImpl = MS.macawExtensions evalFn memVar memCfg
+              let extImpl =
+                    -- We omit the goal evaluator in the case that we have a target
+                    -- override because the target override determines when we have
+                    -- truly reached the goal (by calling the `@reached` built-in).
+                    case mbTargetAddr of
+                      Just targetAddr
+                        | Nothing <- Conf.targetOverride conf ->
+                            GE.goalEvaluatorMacawExtension macawExtImpl sla bak mem rtLoc targetAddr
+                      _ ->
+                        macawExtImpl
+              let dbgOpts = Conf.debugOpts conf
+              let dbgCmdExt = MDebug.macawCommandExt (archCtx ^. Arch.archVals)
+              dbgCtx <- initDebugger sla dbgOpts dbgCmdExt (archCtx ^. Arch.archRegStructType)
+              gssRecState <- RR.mkRecordState halloc
+              gssEmpTrace <- RR.emptyRecordedTrace sym
+              gssRepState <- RR.mkReplayState halloc gssEmpTrace
+              let gssPers = GP.mkPersonality memVar dbgCtx toConc refineData
+              let greaseSimState =
+                    GMSS.mkGreaseSimulatorState gssPers gssRecState gssRepState
+                      & GMSS.discoveredFnHandles .~ discoveredHdls
+              personality <-
+                SP.mkScreachSimulatorState
+                  sym
+                  halloc
+                  greaseSimState
+              GM.initState
+                bak
+                gla
+                extImpl
+                execAction
+                halloc
+                setupMem
+                globals1
+                initFsOv
+                archCtx
+                setupHook
+                addrOvs
+                personality
+                (GS.argVals args)
+                fnOvsMap
+                mbStartupOvSomeSsaCfg
+                (CCC.SomeCFG entryRegSsaCfg)
+          )
 
 withMaybeFile :: Maybe FilePath -> IOMode -> (Maybe Handle -> IO a) -> IO a
 withMaybeFile Nothing _ f = f Nothing
@@ -1353,7 +1335,6 @@ analyzeCfg ::
   ) ->
   IO ()
 analyzeCfg conf sla gla halloc archCtx mbLoadedElf setupHook rtLoc execAction addrOvs entryCfgs pFunc = do
-  let mbEntryAddr = entrypointAddr <$> mbLoadedElf
   let isEcfs = maybe False isECFS mbLoadedElf
   let mbEhi = loadedElf <$> mbLoadedElf
   let mem =

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -969,14 +969,12 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
               GO.Symbolic -> pure MSML.SymbolicMutable
               GO.Uninitialized ->
                 unsupported sla "Macaw does not support uninitialized globals (macaw#372)"
-          (mem0, ptrTable) <-
-            GM.emptyMacawMem
-              bak
-              archCtx
-              mem
-              memModelContents
-              relocs
-          pure (mem0, ptrTable)
+          GM.emptyMacawMem
+            bak
+            archCtx
+            mem
+            memModelContents
+            relocs
         let skipRelocs = GO.SkipUnsupportedRelocs False
         -- NB: We intentionally exclude `mustFailHeuristics` here. This is
         -- primarily because must-fail would incorrectly deem targets that are
@@ -1010,11 +1008,16 @@ initCFG (CCC.SomeCFG entryRegSsaCfg) mbLoadedElf =
             initMem
             inputs
         GR.withErrorCallbacks (GR.setupErrorCallbacks setup) $ do
-          let refineData = GR.setupRefinementData setup
-              toConc = GR.setupToConcretize setup
-              setupMem = GR.setupSetupMem setup
-              initFs = GR.setupInitializedFs setup
-              args = GR.setupArgs setup
+          let GR.RefinementSetup
+                { GR.setupRefinementData = refineData
+                , GR.setupToConcretize = toConc
+                , GR.setupSetupMem = setupMem
+                , GR.setupInitializedFs = initFs
+                , GR.setupArgs = args
+                } = setup
+          -- TODO: When adding support for AArch32 and PPC, override the link
+          -- registers like GREASE does, probably should refactor that in GREASE
+          -- to make it easier to use here - part of ArchCtx?
           let memCfg0 = GM.memConfigInitial bak archCtx ptrTable skipRelocs relocs
           let sym = CB.backendGetSym bak
           let fs = GSIO.initFs initFs

--- a/screach/src/Screach/RefineFeature.hs
+++ b/screach/src/Screach/RefineFeature.hs
@@ -162,7 +162,6 @@ refineState ::
     (C.ExecutionFeatureResult p sym ext rtp)
 refineState bak sla gla refineReplay st config = do
   let pers = C.execResultContext st ^. C.cruciblePersonality
-  let rdata = pers ^. GP.personality . GP.pRefinementData
   let memVar = GP.getMemVar pers
   LJ.writeLog gla (GrDiag.RefineDiagnostic (GRDiag.ExecutionResult memVar st))
   -- Check if execution aborted before trying to prove obligations.
@@ -175,7 +174,7 @@ refineState bak sla gla refineReplay st config = do
     Nothing -> do
       obls <- C.withBackend (C.execResultContext st) $ \bak' ->
         CB.getProofObligations bak'
-      refResult <- GR.proveAndRefine bak st gla rdata obls
+      refResult <- GR.proveAndRefine bak st gla obls
       case refResult of
         GR.ProveSuccess -> do
           doLog sla RDiag.RefinementSuccess
@@ -197,6 +196,7 @@ refineState bak sla gla refineReplay st config = do
                 C.ResultState nres
         GR.ProveRefine shp -> do
           let addrWidth = MC.addrWidthRepr (Proxy @w)
+          let rdata = pers ^. GP.personality . GP.pRefinementData
           LJ.writeLog
             gla
             ( GrDiag.RefineDiagnostic $

--- a/screach/src/Screach/RefineFeature.hs
+++ b/screach/src/Screach/RefineFeature.hs
@@ -200,7 +200,7 @@ refineState bak sla gla refineReplay st config = do
           LJ.writeLog
             gla
             ( GrDiag.RefineDiagnostic $
-                GRDiag.RefinementUsingPrecondition addrWidth (GR.refineArgNames rdata) shp
+                GRDiag.RefinementUsingPrecondition addrWidth (GR.refineInputArgNames (GR.refineInputs rdata)) shp
             )
           CB.clearProofObligations bak
           CB.resetAssumptionState bak

--- a/screach/src/Screach/Verify.hs
+++ b/screach/src/Screach/Verify.hs
@@ -5,7 +5,7 @@
 -- | Reachability verification
 module Screach.Verify (verifyReachable) where
 
-import Control.Lens ((&), (.~), (^.))
+import Control.Lens ((&), (.~))
 import Control.Monad qualified as Monad
 import Data.Macaw.CFG qualified as MC
 import Data.Parameterized.TraversableFC qualified as TFC
@@ -23,7 +23,6 @@ import Lang.Crucible.Backend qualified as CB
 import Lang.Crucible.CFG.Extension qualified as CCE
 import Lang.Crucible.LLVM.MemModel qualified as CLM
 import Lang.Crucible.Simulator qualified as CS
-import Lang.Crucible.Simulator.ExecutionTree qualified as CSE
 import Lang.Crucible.Simulator.RecordAndReplay qualified as CR
 import Lang.Crucible.Types qualified as CT
 import Lumberjack qualified as LJ
@@ -76,11 +75,8 @@ verifyReachable la gla bak initShape execFeats cDataList =
               . CR.initialTrace
               .~ trace
     result' <- CS.executeCrucible (CR.replayFeature True : CR.recordFeature : execFeats) st'
-    let ctx = CSE.execResultContext result'
-    let pers = ctx ^. CS.cruciblePersonality
-    let refineData = pers ^. GP.personality . GP.pRefinementData
     obls <- CB.getProofObligations bak
-    refResult <- GR.proveAndRefine bak result' gla refineData obls
+    refResult <- GR.proveAndRefine bak result' gla obls
     case refResult of
       GR.ProveBug bugInstance _
         | isReachedBug bugInstance ->


### PR DESCRIPTION
- Factor out `RefineInputs` to shrink argument lists
- Add `setupRefinement` to set up error maps, initial fs, etc.
- Add `RefinementSetup` as the output of the above, fewer and smaller continuations

`setupRefinement` is also exactly the abstraction that will be needed for part of #633, specifically verification of reachability results.