### PR TITLE
feat(overrides): `@write-byte-vec`

### DIFF
--- a/doc/builtins.md
+++ b/doc/builtins.md
@@ -236,6 +236,7 @@ See [The S-expression language](sexp.md) for more details.
 (declare @unique-conc-vector-bv-32 ((v (Vector (Bitvector 32)))) (Vector (Bitvector 32)))
 (declare @unique-conc-vector-bv-64 ((v (Vector (Bitvector 64)))) (Vector (Bitvector 64)))
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector w))) (Vector (Bitvector 8)))
+(declare @write-byte-vec ((dest (Ptr w)) (src (Vector (Bitvector 8)))) Unit)
 ```
 
 For LLVM S-expression files (programs or overrides), the following overrides are also available:
@@ -251,7 +252,7 @@ For LLVM S-expression files (programs or overrides), the following overrides are
 The following overrides merit a bit of discussion:
 
 - `accept`, `bind`, `connect`, `listen`, `recv`, `send`, and `socket`: see
-  [I/O](io.md)>
+  [I/O](io.md)
 
 - `abort`
 

--- a/doc/sexp.md
+++ b/doc/sexp.md
@@ -103,13 +103,15 @@ These overrides check if all elements of the vector have unique concrete values
 across all satisfying models. If all elements are uniquely determined, returns
 the concrete vector; otherwise returns the symbolic vector unchanged.
 
-### `@fresh-bytes`
+### `@fresh-bytes` and `@write-byte-vec`
 
-The bytes created using `fresh-bytes` will be concretized and printed to the
-terminal if GREASE finds a possible bug.
+The bytes created using `fresh-bytes` will be concretized and printed to
+the terminal if GREASE finds a possible bug. In contrast to `@write-bytes`,
+`@write-byte-vec` does *not* add a null terminator.
 
-`fresh-bytes` can be used to create overrides for functions that do I/O, such
-as the following basic override for `recv`, shown for x86_64 and LLVM:
+`fresh-bytes` and `write-byte-vec` can be combined to create overrides for
+functions that do I/O, such as the following basic override for `recv`, shown
+for x86_64 and LLVM:
 
 ```
 ; Basic x86_64 override for `recv`.
@@ -117,31 +119,14 @@ as the following basic override for `recv`, shown for x86_64 and LLVM:
 ; Ignores `socket` and `flags`, always reads exactly `length` bytes.
 
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+(declare @write-byte-vec ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
 
 ; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
 (defun @recv ((socket (Ptr 64)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 64))) (Ptr 64)
-  (registers
-    ($ctr (Bitvector 64))  ; loop counter (going down)
-    ($idx Nat)             ; index into vector of bytes
-    ($ptr (Ptr 64)))       ; pointer to write the next byte into
   (start start:
     (let length-bv (pointer-to-bits length))
     (let bytes (funcall @fresh-bytes "recv" length-bv))
-
-    (set-register! $ctr length-bv)
-    (set-register! $idx 0)
-    (set-register! $ptr buffer)
-    (jump loop:))
-  (defblock loop:
-    (let byte (vector-get bytes $idx))
-    (pointer-write (Bitvector 8) le $ptr byte)
-
-    (set-register! $ctr (- $ctr (bv 64 1)))
-    (set-register! $idx (+ $idx 1))
-    (let ptr (pointer-add $ptr (bv 64 1)))
-    (set-register! $ptr ptr)
-    (branch (equal? $ctr (bv 64 0)) end: loop:))
-  (defblock end:
+    (funcall @write-byte-vec buffer bytes)
     (return length)))
 ```
 ```
@@ -150,42 +135,28 @@ as the following basic override for `recv`, shown for x86_64 and LLVM:
 ; Ignores `socket` and `flags`. Always reads exactly `length` bytes.
 
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+(declare @write-byte-vec ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
 
 ; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
 (defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
-  (registers
-    ($ctr (Bitvector 64))  ; loop counter (going down)
-    ($idx Nat)             ; index into vector of bytes
-    ($ptr (Ptr 64)))       ; pointer to write the next byte into
   (start start:
     (let length-bv (ptr-offset 64 length))
     (let bytes (funcall @fresh-bytes "recv" length-bv))
-
-    (set-register! $ctr length-bv)
-    (set-register! $idx 0)
-    (set-register! $ptr buffer)
-    (jump loop:))
-  (defblock loop:
-    (let byte (vector-get bytes $idx))
-    (let byte-ptr (ptr 8 0 byte))
-    (store none i8 $ptr byte-ptr)
-
-    (set-register! $ctr (- $ctr (bv 64 1)))
-    (set-register! $idx (+ $idx 1))
-    (let ptr (ptr-add-offset $ptr (bv 64 1)))
-    (set-register! $ptr ptr)
-    (branch (equal? $ctr (bv 64 0)) end: loop:))
-  (defblock end:
+    (funcall @write-byte-vec buffer bytes)
     (return length)))
 ```
+
+`fresh-bytes` returns the bytes as a `Vector (Bitvector 8)`, which can be
+inspected or manipulated before being passed to `write-byte-vec`.
 
 ### LLVM-specific overrides
 
 For LLVM S-expression files (programs or overrides), the following overrides are also available:
 ```
 (declare @read-bytes ((x (Ptr 64))) (Vector (Bitvector 8)))
-(declare @read-c-string ((x (Ptr 64))) (String Unicode))
-(declare @write-bytes ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
+(declare @read-c-string ((x (Ptr 64))) (String Unicode)) (declare @write-bytes
+((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)`@write-byte-vec` does *not*
+add a null terminator.
 (declare @write-c-string ((dst (Ptr 64)) (src (String Unicode))) Unit)
 ```
 

--- a/grease-exe/tests/llvm/extra/recv.llvm.cbl
+++ b/grease-exe/tests/llvm/extra/recv.llvm.cbl
@@ -1,38 +1,18 @@
 ; Copyright (c) Galois, Inc. 2025
 
-; Override for `recv` that uses `fresh-bytes`.
+; Override for `recv` that uses `fresh-bytes` + `write-byte-vec`.
 ;
 ; Ignores `socket` and `flags`, always reads exactly `length` bytes.
 ;
 ; Appears in the docs in `doc/sexp.md`.
 
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+(declare @write-byte-vec ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
 
 ; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
 (defun @recv ((socket (Ptr 32)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 32))) (Ptr 64)
-  ; This is a bit more awkward than it needs to be, because there are no
-  ; pointer<->integer<->nat conversions in crucible-syntax.
-  (registers
-    ($ctr (Bitvector 64))  ; loop counter (going down)
-    ($idx Nat)             ; index into vector of bytes
-    ($ptr (Ptr 64)))       ; pointer to write the next byte into
   (start start:
     (let length-bv (ptr-offset 64 length))
     (let bytes (funcall @fresh-bytes "recv" length-bv))
-
-    (set-register! $ctr length-bv)
-    (set-register! $idx 0)
-    (set-register! $ptr buffer)
-    (jump loop:))
-  (defblock loop:
-    (let byte (vector-get bytes $idx))
-    (let byte-ptr (ptr 8 0 byte))
-    (store none i8 $ptr byte-ptr)
-
-    (set-register! $ctr (- $ctr (bv 64 1)))
-    (set-register! $idx (+ $idx 1))
-    (let ptr (ptr-add-offset $ptr (bv 64 1)))
-    (set-register! $ptr ptr)
-    (branch (equal? $ctr (bv 64 0)) end: loop:))
-  (defblock end:
+    (funcall @write-byte-vec buffer bytes)
     (return length)))

--- a/grease-exe/tests/x86/extra/recv.x64.cbl
+++ b/grease-exe/tests/x86/extra/recv.x64.cbl
@@ -1,35 +1,16 @@
-; Override for `recv` that uses `fresh-bytes`.
+; Override for `recv` that uses `fresh-bytes` + `write-byte-vec`.
 ;
 ; Ignores `socket` and `flags`, always reads exactly `length` bytes.
 ;
 ; Appears in the docs in `doc/sexp.md`.
 
 (declare @fresh-bytes ((name (String Unicode)) (num (Bitvector 64))) (Vector (Bitvector 8)))
+(declare @write-byte-vec ((dest (Ptr 64)) (src (Vector (Bitvector 8)))) Unit)
 
 ; `man 2 recv`: ssize_t recv(int socket, void *buffer, size_t length, int flags)
 (defun @recv ((socket (Ptr 64)) (buffer (Ptr 64)) (length (Ptr 64)) (flags (Ptr 64))) (Ptr 64)
-  ; This is a bit more awkward than it needs to be, because there are no
-  ; pointer<->integer<->nat conversions in crucible-syntax.
-  (registers
-    ($ctr (Bitvector 64))  ; loop counter (going down)
-    ($idx Nat)             ; index into vector of bytes
-    ($ptr (Ptr 64)))       ; pointer to write the next byte into
   (start start:
     (let length-bv (pointer-to-bits length))
     (let bytes (funcall @fresh-bytes "recv" length-bv))
-
-    (set-register! $ctr length-bv)
-    (set-register! $idx 0)
-    (set-register! $ptr buffer)
-    (jump loop:))
-  (defblock loop:
-    (let byte (vector-get bytes $idx))
-    (pointer-write (Bitvector 8) le $ptr byte)
-
-    (set-register! $ctr (- $ctr (bv 64 1)))
-    (set-register! $idx (+ $idx 1))
-    (let ptr (pointer-add $ptr (bv 64 1)))
-    (set-register! $ptr ptr)
-    (branch (equal? $ctr (bv 64 0)) end: loop:))
-  (defblock end:
+    (funcall @write-byte-vec buffer bytes)
     (return length)))

--- a/grease/src/Grease/LLVM/Overrides.hs
+++ b/grease/src/Grease/LLVM/Overrides.hs
@@ -35,7 +35,7 @@ import Grease.LLVM.Overrides.SExp qualified as GLOS
 import Grease.Overrides (CantResolveOverrideCallback (CantResolveOverrideCallback))
 import Grease.Personality qualified as GP
 import Grease.Skip (declSkipOverride, registerSkipOverride)
-import Grease.Syntax.Overrides (freshBytesOverride, tryBindTypedOverride)
+import Grease.Syntax.Overrides (freshBytesOverride, tryBindTypedOverride, writeByteVecOverride)
 import Grease.Syntax.Overrides.Concretize qualified as Conc
 import Grease.Utility (OnlineSolverAndBackend, llvmOverrideName)
 import Lang.Crucible.Backend qualified as CB
@@ -544,6 +544,9 @@ registerLLVMForwardDeclarations bak funOvs errCb fwdDecs = do
             unless ok (cannotResolve fwdDecName hdl)
           "write-bytes" -> do
             ok <- tryBindTypedOverride hdl (StrOv.writeBytesOverride mvar)
+            unless ok (cannotResolve fwdDecName hdl)
+          "write-byte-vec" -> do
+            ok <- tryBindTypedOverride hdl writeByteVecOverride
             unless ok (cannotResolve fwdDecName hdl)
           "write-c-string" -> do
             ok <- tryBindTypedOverride hdl (StrOv.writeCStringOverride mvar)

--- a/grease/src/Grease/Macaw/Overrides.hs
+++ b/grease/src/Grease/Macaw/Overrides.hs
@@ -264,6 +264,8 @@ registerMacawOvForwardDeclarations ::
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , ToConc.HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | The map of public function names to their overrides.
@@ -284,6 +286,8 @@ registerMacawForwardDeclarations ::
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , ToConc.HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | The map of public function names to their overrides.
@@ -305,6 +309,9 @@ registerMacawForwardDeclaration ::
   ( OnlineSolverAndBackend solver sym bak scope st fs
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , ToConc.HasToConcretize p
+  , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | The map of public function names to their overrides.
@@ -331,6 +338,9 @@ lookupMacawForwardDeclarationOverride ::
   ( OnlineSolverAndBackend solver sym bak scope st fs
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , ToConc.HasToConcretize p
+  , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | The map of public function names to their overrides.
@@ -348,6 +358,10 @@ lookupMacawForwardDeclarationOverride bak funOvs decName hdl =
       case decName of
         "fresh-bytes" -> do
           let ov = SExp.freshBytesOverride @_ @p @sym @(Symbolic.MacawExt arch) ?ptrWidth
+          (C.Refl, C.Refl) <- SExp.checkTypedOverrideHandleCompat hdl ov
+          Just (CS.runTypedOverride (C.handleName hdl) ov)
+        "write-byte-vec" -> do
+          let ov = SExp.writeByteVecOverride @_ @sym @p @(Symbolic.MacawExt arch)
           (C.Refl, C.Refl) <- SExp.checkTypedOverrideHandleCompat hdl ov
           Just (CS.runTypedOverride (C.handleName hdl) ov)
         "conc-bv-8" -> Conc.tryConcBvOverride bak (C.knownNat @8) hdl

--- a/grease/src/Grease/Macaw/Overrides/Address.hs
+++ b/grease/src/Grease/Macaw/Overrides/Address.hs
@@ -262,6 +262,8 @@ registerAddressOverrideForwardDeclarations ::
   , bak ~ LCBO.OnlineBackend solver scope st fs
   , HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | What to do when a forward declaration cannot be resolved.
@@ -298,6 +300,8 @@ registerAddressOverrideHandles ::
   , bak ~ LCBO.OnlineBackend solver scope st fs
   , HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | What to do when a forward declaration cannot be resolved.

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
 {-# LANGUAGE MultiWayIf #-}
 {-# LANGUAGE OverloadedStrings #-}
 
@@ -71,6 +72,7 @@ import Grease.Macaw.SkippedCall (
  )
 import Grease.Macaw.Syscall (macawSyscallOverride)
 import Grease.Options qualified as Opts
+import Grease.Personality qualified as GP
 import Grease.Syntax (ResolvedOverridesYaml, getResolvedOverridesYaml)
 import Grease.Utility (OnlineSolverAndBackend, segoffToAbsoluteAddr)
 import Lang.Crucible.Analysis.Postdom qualified as C
@@ -154,6 +156,7 @@ defaultLookupFunctionHandleDispatch ::
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , HasToConcretize p
   , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   GreaseLogAction ->
@@ -623,6 +626,9 @@ useMacawSExpOverride ::
   , bak ~ C.OnlineBackend solver scope st fs
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , HasToConcretize p
+  , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   GreaseLogAction ->
@@ -668,6 +674,9 @@ extendHandleMap ::
   , bak ~ C.OnlineBackend solver scope st fs
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , HasToConcretize p
+  , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | Map of names of overridden functions to their implementations

--- a/grease/src/Grease/Macaw/SetupHook.hs
+++ b/grease/src/Grease/Macaw/SetupHook.hs
@@ -65,6 +65,7 @@ newtype SetupHook sym arch
         , CLM.HasLLVMAnn sym
         , HasGreaseSimulatorState p sym bak t cExt arch ret argTys wptr
         , HasToConcretize p
+        , ?memOpts :: CLM.MemOptions
         ) =>
         bak ->
         -- Map of names of overridden functions to their implementations
@@ -96,6 +97,8 @@ registerOverrideForwardDeclarations ::
   , bak ~ LCB.OnlineBackend solver scope st fs
   , HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | What to do when a forward declaration cannot be resolved.
@@ -123,6 +126,8 @@ registerOverrideHandles ::
   , bak ~ LCB.OnlineBackend solver scope st fs
   , HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   bak ->
   -- | What to do when a forward declaration cannot be resolved.

--- a/grease/src/Grease/Syntax/Overrides.hs
+++ b/grease/src/Grease/Syntax/Overrides.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ExplicitNamespaces #-}
 {-# LANGUAGE GADTs #-}
+{-# LANGUAGE ImplicitParams #-}
 
 -- |
 -- Copyright        : (c) Galois, Inc. 2025
@@ -9,8 +10,10 @@ module Grease.Syntax.Overrides (
   checkTypedOverrideHandleCompat,
   tryBindTypedOverride,
   freshBytesOverride,
+  writeByteVecOverride,
 ) where
 
+import Control.Lens ((^.))
 import Control.Monad qualified as Monad
 import Control.Monad.IO.Class (liftIO)
 import Data.BitVector.Sized qualified as BV
@@ -22,8 +25,11 @@ import Data.Type.Equality (testEquality, (:~:) (Refl))
 import Data.Type.Ord (type (<=))
 import Data.Vector qualified as Vec
 import Grease.Concretize.ToConcretize qualified as ToConc
+import Grease.Personality qualified as GP
 import Lang.Crucible.Backend qualified as CB
 import Lang.Crucible.FunctionHandle qualified as LCF
+import Lang.Crucible.LLVM.DataLayout qualified as CLD
+import Lang.Crucible.LLVM.MemModel qualified as CLM
 import Lang.Crucible.Simulator qualified as CS
 import Lang.Crucible.Types qualified as LCT
 import What4.Interface qualified as WI
@@ -119,3 +125,49 @@ doFreshBytes name len =
     ToConc.addToConcretize name entry
 
     pure v
+
+---------------------------------------------------------------------
+
+-- | Override for @write-byte-vec@.
+--
+-- Writes the bytes from the vector to the given buffer pointer without adding
+-- any null terminator. Can be combined with @fresh-bytes@ to write fresh
+-- symbolic bytes to a buffer.
+writeByteVecOverride ::
+  ( CLM.HasPtrWidth w
+  , CLM.HasLLVMAnn sym
+  , GP.HasMemVar p
+  , ?memOpts :: CLM.MemOptions
+  ) =>
+  CS.TypedOverride
+    p
+    sym
+    ext
+    (Ctx.EmptyCtx Ctx.::> CLM.LLVMPointerType w Ctx.::> LCT.VectorType (LCT.BVType 8))
+    LCT.UnitType
+writeByteVecOverride =
+  WI.withKnownNat ?ptrWidth $
+    CS.typedOverride (Ctx.uncurryAssignment writeByteVecImpl)
+
+-- | Implementation of the @write-byte-vec@ override.
+writeByteVecImpl ::
+  ( CLM.HasPtrWidth w
+  , CLM.HasLLVMAnn sym
+  , GP.HasMemVar p
+  , ?memOpts :: CLM.MemOptions
+  ) =>
+  CS.RegValue' sym (CLM.LLVMPointerType w) ->
+  CS.RegValue' sym (LCT.VectorType (LCT.BVType 8)) ->
+  CS.OverrideSim p sym ext r args ret ()
+writeByteVecImpl ptr bytes = do
+  ctx <- CS.getContext
+  let mvar = GP.getMemVar (ctx ^. CS.cruciblePersonality)
+  CS.ovrWithBackend $ \bak -> do
+    let sym = CB.backendGetSym bak
+    CS.modifyGlobal mvar $ \mem -> do
+      zeroNat <- liftIO $ WI.natLit sym 0
+      let llvmVals = Vec.map (CLM.LLVMValInt zeroNat) (CS.unRV bytes)
+      let val = CLM.LLVMValArray (CLM.bitvectorType 1) llvmVals
+      let storTy = CLM.llvmValStorableType val
+      mem' <- liftIO $ CLM.storeRaw bak mem (CS.unRV ptr) storTy CLD.noAlignment val
+      pure ((), mem')

--- a/screach/src/Screach.hs
+++ b/screach/src/Screach.hs
@@ -534,6 +534,8 @@ setupHookCommon ::
   , CLM.HasPtrWidth (MC.ArchAddrWidth arch)
   , ToConc.HasToConcretize p
   , GP.HasMemVar p
+  , CLM.HasLLVMAnn sym
+  , ?memOpts :: CLM.MemOptions
   ) =>
   ScreachLogAction ->
   bak ->


### PR DESCRIPTION
Fixes #654. Especially useful for using `@fresh-bytes` with a low loop bound.