### PR TITLE
tests: Embed CFLAGS in C files for binary tests, too

### DIFF
--- a/doc/dev/tests.md
+++ b/doc/dev/tests.md
@@ -105,12 +105,15 @@ void test(/* ... */) { /* ... */ }
 
 ## Embedded C compiler flags
 
-Tests in the `llvm-bc/` directory may embed additional flags to pass to the C
-compiler using the special comment syntax `// CFLAGS: `, e.g., `// CFLAGS: -g`.
+Binary executable tests (`.armv7l.elf`, `.x64.elf`, `.ppc32.elf`) and tests in
+the `llvm-bc/` directory may embed additional flags to pass to the C compiler
+using the special comment syntax `// CFLAGS: `, e.g., `// CFLAGS: -g`.
 
-The script that extracts these flags also supports flag *groups*, which start
-with `$`. The only flag group currently supported is `$LLVM`, which expands to
-`-emit-llvm -frecord-command-line`.
+Binary tests default to `$(CFLAGS)` (static, no-pie, no-libs) when no
+`// CFLAGS:` directive is present.
+
+The script also supports flag *groups* (e.g., `$LLVM`, `$DYNAMIC`); see
+`grease-exe/tests/extract-cflags.py` for the full list.
 
 ## Writing good tests
 

--- a/grease-exe/tests/Makefile
+++ b/grease-exe/tests/Makefile
@@ -7,7 +7,8 @@ PPC32CC = powerpc-linux-musl-gcc
 # A reasonable default set of CC flags that aims to make binaries as small as
 # possible. It is possible that this default will not work for all test cases,
 # however. If you want to add a test case that changes one or more of these
-# flags, consider splitting it out into its own variable.
+# flags, embed the desired flags in the test file using a // CFLAGS: directive
+# (see doc/dev/tests.md and extract-cflags.py).
 #
 # Explanations for additional flags:
 # -static: Generally, we prefer self-contained test binaries.
@@ -50,12 +51,12 @@ DYNAMIC_DIRS = \
 DYNAMIC_ARM_EXES   = $(addsuffix /test.armv7l.elf,$(DYNAMIC_DIRS))
 DYNAMIC_PPC32_EXES = $(addsuffix /test.ppc32.elf,$(DYNAMIC_DIRS))
 
-# This test case requires the use of position-independent executables.
+# These test cases require the use of position-independent executables.
 DYNAMIC_PIE_DIRS = refine/bug/null_ptr_deref_pie refine/pos/pie
 DYNAMIC_PIE_ARM_EXES   = $(addsuffix /test.armv7l.elf,$(DYNAMIC_PIE_DIRS))
 DYNAMIC_PIE_PPC32_EXES = $(addsuffix /test.ppc32.elf,$(DYNAMIC_PIE_DIRS))
 
-# This test case requires the use of stripped binaries.
+# These test cases require the use of stripped binaries.
 STRIPPED_STATIC_DIRS = refine/pos/stripped refine/pos/stripped_with_overrides
 STRIPPED_STATIC_ARM_EXES   = $(addsuffix /test.armv7l.elf,$(STRIPPED_STATIC_DIRS))
 STRIPPED_STATIC_X64_EXES   = $(addsuffix /test.x64.elf,$(STRIPPED_STATIC_DIRS))
@@ -80,6 +81,7 @@ STATIC_WITH_LIBS_PPC32_EXES = $(addsuffix /test.ppc32.elf,$(STATIC_WITH_LIBS_DIR
 #
 # Sadly, clang will balk if you attempt to combine -fstack-protector-all with
 # -nostartfiles, so this test case must be compiled with startup code bloat.
+# See the $STACK_PROTECTOR group in extract-cflags.py.
 STACK_PROTECTOR_DIRS = refine/pos/stack_protector
 STACK_PROTECTOR_ARM_EXES = $(addsuffix /test.armv7l.elf,$(STACK_PROTECTOR_DIRS))
 STACK_PROTECTOR_X64_EXES = $(addsuffix /test.x64.elf,$(STACK_PROTECTOR_DIRS))
@@ -175,50 +177,26 @@ all: $(EXES) $(SOS) $(BCS) $(STANDALONE_BCS)
 fmt:
 	clang-format -i $(DIRS:=/test.c)
 
-$(STATIC_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS) -o $@ $<
+%/test.armv7l.elf: %/test.c
+	$(ARMCC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 
-$(STATIC_X64_EXES): %/test.x64.elf: %/test.c
-	$(X64CC) $(CFLAGS) -o $@ $<
+%/test.x64.elf: %/test.c
+	$(X64CC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 
-$(STATIC_PPC32_EXES): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS) -o $@ $<
+%/test.ppc32.elf: %/test.c
+	$(PPC32CC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 
 $(STRIPPED_STATIC_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS) -o $@ $<
+	$(ARMCC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 	armv7l-linux-musleabi-strip $@
 
 $(STRIPPED_STATIC_X64_EXES): %/test.x64.elf: %/test.c
-	$(X64CC) $(CFLAGS) -o $@ $<
+	$(X64CC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 	strip $@
 
 $(STRIPPED_STATIC_PPC32_EXES): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS) -o $@ $<
+	$(PPC32CC) $(or $(shell ./extract-cflags.py $<),$(CFLAGS)) -o $@ $<
 	powerpc-linux-musl-strip $@
-
-$(STATIC_WITH_LIBS_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS_COMMON) $(CFLAGS_STATIC) -o $@ $<
-
-$(STATIC_WITH_LIBS_PPC32_EXES): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS_COMMON) $(CFLAGS_STATIC) -o $@ $<
-
-$(STACK_PROTECTOR_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) -fstack-protector-all $(CFLAGS_STATIC) -o $@ $<
-
-$(STACK_PROTECTOR_X64_EXES): %/test.x64.elf: %/test.c
-	$(X64CC) -fstack-protector-all $(CFLAGS_STATIC) -o $@ $<
-
-$(DYNAMIC_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS_COMMON) -no-pie -o $@ $<
-
-$(DYNAMIC_PPC32_EXES): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS_COMMON) -no-pie -o $@ $<
-
-$(DYNAMIC_PIE_ARM_EXES): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS_COMMON) -fpic -o $@ $<
-
-$(DYNAMIC_PIE_PPC32_EXES): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS_COMMON) -fpic -o $@ $<
 
 $(SHARED_LIBRARY_ARM_SOS): %/libaux.armv7l.so: %/aux.c
 	$(ARMCC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -fpic -shared $< -o $@
@@ -238,26 +216,19 @@ $(SHARED_LIBRARY_PPC32_SOS): %/libaux.ppc32.so: %/aux.c
 $(SHARED_LIBRARY_PPC32_EXES): %/test.ppc32.elf: %/test.c %/libaux.ppc32.so
 	$(PPC32CC) $(CFLAGS_COMMON) -nostartfiles -fpic -L$(dir $@) $< -laux.ppc32 -o $@
 
-$(STANDALONE_SHARED_LIBRARY_ARM_SOS): %/test.armv7l.elf: %/test.c
-	$(ARMCC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -fpic -shared $< -o $@
-
-$(STANDALONE_SHARED_LIBRARY_X64_SOS): %/test.x64.elf: %/test.c
-	$(X64CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -fpic -shared $< -o $@
-
-$(STANDALONE_SHARED_LIBRARY_PPC32_SOS): %/test.ppc32.elf: %/test.c
-	$(PPC32CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -fpic -shared $< -o $@
-
-$(SHARED_LIBARY_DWARFV4_X64_SOS): %/test.x64.elf: %/test.c
-	$(X64CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -gdwarf-4 -fpic -shared $< -o $@
-
-$(SHARED_LIBARY_DWARFV5_X64_SOS): %/test.x64.elf: %/test.c
-	$(X64CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -gdwarf-5 -fpic -shared $< -o $@
-
 $(ASSEMBLY_ARM_EXES): %/extra/test.armv7l.elf: %/test.S
 	$(ARMCC) $(CFLAGS) $< -o $@
 
  $(ASSEMBLY_SHARED_LIBRARY_X64_SOS): %/extra/test.x64.elf: %/test.S
 	$(X64CC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) -shared $< -o $@
+
+# libpng uses $STATIC_WITH_LIBS for ARM/PPC32 but full $(CFLAGS) for x64
+# (the x64 exe falls through to the generic rule above).
+refine/neg/libpng-cve-2018-13785/test.armv7l.elf: refine/neg/libpng-cve-2018-13785/test.c
+	$(ARMCC) $(CFLAGS_COMMON) $(CFLAGS_STATIC) -o $@ $<
+
+refine/neg/libpng-cve-2018-13785/test.ppc32.elf: refine/neg/libpng-cve-2018-13785/test.c
+	$(PPC32CC) $(CFLAGS_COMMON) $(CFLAGS_STATIC) -o $@ $<
 
 $(RAW_BINARY_EXES): %/test.armv7l.elf: %/test.c
 	$(ARMCC) $(CFLAGS_COMMON) $(CFLAGS_NO_LIBS) $(CFLAGS_STATIC) -c $< -o  $*/test.o

--- a/grease-exe/tests/extract-cflags.py
+++ b/grease-exe/tests/extract-cflags.py
@@ -10,7 +10,21 @@ from sys import exit, stderr
 
 COMMENT = "// CFLAGS: "
 
-GROUPS = {"LLVM": ["-emit-llvm", "-frecord-command-line"]}
+_COMMON = [
+    "-fno-stack-protector",
+    "-Wl,--unresolved-symbols=ignore-all",
+    "-nostartfiles",
+]
+_NO_LIBS = ["-nodefaultlibs", "-nolibc", "-nostdlib"]
+_STATIC = ["-static", "-no-pie"]
+
+GROUPS = {
+    "LLVM": ["-emit-llvm", "-frecord-command-line"],
+    "COMMON": _COMMON,
+    "STATIC": _STATIC,
+    "STATIC_WITH_LIBS": _COMMON + _STATIC,
+    "SHARED_LIB": _COMMON + _NO_LIBS + ["-fpic", "-shared"],
+}
 
 
 def eprint(*args, **kwargs):

--- a/grease-exe/tests/refine/bug/assert_false/test.c
+++ b/grease-exe/tests/refine/bug/assert_false/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // all: flags {"--symbol", "test"}
 // all: go(prog)
 

--- a/grease-exe/tests/refine/bug/null_ptr_deref_pie/test.c
+++ b/grease-exe/tests/refine/bug/null_ptr_deref_pie/test.c
@@ -1,3 +1,5 @@
+// CFLAGS: $COMMON -fpic
+
 // A regression test for gitlab#254 and gitlab#255. This ensures that
 // dereferencing a null pointer will be flagged as a possible bug even when
 // analyzing a position-independent executable (PIE). In PIE binaries, it is

--- a/grease-exe/tests/refine/pos/excluded_overrides/test.c
+++ b/grease-exe/tests/refine/pos/excluded_overrides/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // A regression test for gitlab#226, which ensures that we do not convert LLVM
 // overrides to Macaw overrides that do not work well with macaw-symbolic's
 // lazy memory model.

--- a/grease-exe/tests/refine/pos/getppid_syscall_override/test.c
+++ b/grease-exe/tests/refine/pos/getppid_syscall_override/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $STATIC_WITH_LIBS
+
 // all: flags {"--symbol", "test"}
 // all: go(prog)
 

--- a/grease-exe/tests/refine/pos/malloc-free-external/test.c
+++ b/grease-exe/tests/refine/pos/malloc-free-external/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // A variant of the malloc-free test case that dynamically links against libc
 // instead of redefining malloc and free. This ensures that the calls to malloc
 // and free come from an external shared library, which requires a different

--- a/grease-exe/tests/refine/pos/malloc/test.c
+++ b/grease-exe/tests/refine/pos/malloc/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // all: flags {"--symbol", "test"}
 // ppc32: flags {"--plt-stub", "0x10000220:malloc"}
 // all: go(prog)

--- a/grease-exe/tests/refine/pos/pie/test.c
+++ b/grease-exe/tests/refine/pos/pie/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -fpic
+
 // all: flags {"--symbol", "test"}
 // ppc32: flags {"--plt-stub", "0x270:malloc", "--plt-stub", "0x280:free"}
 // all: go(prog)

--- a/grease-exe/tests/refine/pos/printf/test.c
+++ b/grease-exe/tests/refine/pos/printf/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // A regression test for gitlab#219 which ensures that we do not attempt to use
 // a buggy override for `printf`. The current approach is that `grease` will
 // not register a built-in override for `printf` at all, instead skipping any

--- a/grease-exe/tests/refine/pos/stack_protector/test.c
+++ b/grease-exe/tests/refine/pos/stack_protector/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $STATIC -fstack-protector-all
+
 // A test case for gitlab#132. This doesn't really do anything interesting on
 // its own. Instead, the interesting part is compiling this program with
 // -fstack-protector-all, which causes the generated assembly code to emit

--- a/grease-exe/tests/sanity/pass/dwarf-array/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-array/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that we can parse an array via dwarf.
 
 struct bar {

--- a/grease-exe/tests/sanity/pass/dwarf-conservative-shapes/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-conservative-shapes/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that with a conservative shape we a. dont try to parse a union
 // b. dont attempt to make separate fields for bar
 

--- a/grease-exe/tests/sanity/pass/dwarf-default-for-field-members-and-pointers/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-default-for-field-members-and-pointers/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that we can still succeed without heuristics to load fields prior to a
 // failure and after a function pointer
 

--- a/grease-exe/tests/sanity/pass/dwarf-fail-to-parse-log/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-fail-to-parse-log/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that we log a failure to parse for an unsupported dwarf type (Unions)
 // See issue #262
 

--- a/grease-exe/tests/sanity/pass/dwarf-restrict-ptr-and-typedef/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-restrict-ptr-and-typedef/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that heuristics are unneeded when using dwarf populated shapes to
 // create a memory precondition that allows foo to execute. Uses a typedef
 // and restrict, shows that GREASE parses through these DWARF tags.

--- a/grease-exe/tests/sanity/pass/dwarf-shape-recursive-tree/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-shape-recursive-tree/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
 // Tests that heuristics are unneeded when using dwarf populated shapes
 // to initialize a tree. The tree has an implicit invariant that if next != null then both 
 // lhs and rhs are initialized.

--- a/grease-exe/tests/sanity/pass/dwarf-shape-recursive/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-shape-recursive/test.c
@@ -1,6 +1,8 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
-// Tests that heuristics are unneeded when using dwarf populated shapes to 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
+// Tests that heuristics are unneeded when using dwarf populated shapes to
 // create a memory precondition that allows sum_list to execute.
 // Tests that the recursive type instantiation is bounded 
 

--- a/grease-exe/tests/sanity/pass/dwarf-shapes-dwarfv4/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-shapes-dwarfv4/test.c
@@ -1,6 +1,8 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
-// Tests that heuristics are unneeded when using dwarf populated shapes to 
+// CFLAGS: $SHARED_LIB -gdwarf-4
+
+// Tests that heuristics are unneeded when using dwarf populated shapes to
 // create a memory precondition that allows foo to execute.
 
 struct bar {

--- a/grease-exe/tests/sanity/pass/dwarf-shapes/test.c
+++ b/grease-exe/tests/sanity/pass/dwarf-shapes/test.c
@@ -1,6 +1,8 @@
 /* Copyright (c) Galois, Inc. 2025 */
 
-// Tests that heuristics are unneeded when using dwarf populated shapes to 
+// CFLAGS: $SHARED_LIB -gdwarf-5
+
+// Tests that heuristics are unneeded when using dwarf populated shapes to
 // create a memory precondition that allows foo to execute.
 
 struct bar {

--- a/grease-exe/tests/sanity/pass/simulate_from_shared_library/test.c
+++ b/grease-exe/tests/sanity/pass/simulate_from_shared_library/test.c
@@ -1,3 +1,5 @@
+// CFLAGS: $SHARED_LIB
+
 // A regression test for gitlab#249. What makes this test unique is that this
 // is compiled to a shared library rather than a standalone executable, and as
 // a result, most compilers will compile the call to `deref` in `test` to a PLT

--- a/grease-exe/tests/sanity/pass/startup-override/test.c
+++ b/grease-exe/tests/sanity/pass/startup-override/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $COMMON -no-pie
+
 // arm: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.armv7l.cbl"}
 // ppc32: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.ppc32.cbl", "--plt-stub", "0x10000220:memset"}
 // x64: flags {"--symbol-startup-override", "test:tests/sanity/pass/startup-override/startup-override.aux.x86_64.cbl"}

--- a/grease-exe/tests/sanity/pass/syscall/test.c
+++ b/grease-exe/tests/sanity/pass/syscall/test.c
@@ -1,5 +1,7 @@
 /* Copyright (c) Galois, Inc. 2024 */
 
+// CFLAGS: $STATIC_WITH_LIBS
+
 // A simple test that does nothing but call alarm(), which performs a syscall.
 // Currently, GREASE will treat all syscalls as no-ops.
 


### PR DESCRIPTION
We already did this for LLVM bitcode tests, it's a nice way to reduce the number of tests that require custom Make rules, and to make tests a bit more self-contained.