### PR TITLE
screach: Use strict `StateT`

### DIFF
--- a/screach/src/Screach/Distance.hs
+++ b/screach/src/Screach/Distance.hs
@@ -32,7 +32,7 @@ import Control.Monad (forM, forM_)
 import Control.Monad qualified as Monad
 import Control.Monad.Reader (ReaderT)
 import Control.Monad.Reader qualified as Reader
-import Control.Monad.State.Lazy (MonadIO (liftIO), MonadState (get, put), StateT, modify, runStateT)
+import Control.Monad.State.Strict (MonadIO (liftIO), MonadState (get, put), StateT, modify, runStateT)
 import Control.Monad.Trans.Class (MonadTrans (lift))
 import Control.Monad.Trans.Maybe
 import Control.Monad.Trans.Reader (mapReaderT)

--- a/screach/src/Screach/ShortestDistanceScheduler.hs
+++ b/screach/src/Screach/ShortestDistanceScheduler.hs
@@ -13,7 +13,7 @@ module Screach.ShortestDistanceScheduler (sdsePrioritizationFunction, HasDistanc
 import Control.Applicative ((<|>))
 import Control.Monad (forM)
 import Control.Monad.Reader (ReaderT (runReaderT))
-import Control.Monad.State (MonadIO (liftIO), MonadTrans (lift), StateT, runStateT)
+import Control.Monad.State.Strict (MonadIO (liftIO), MonadTrans (lift), StateT, runStateT)
 import Control.Monad.Trans.Maybe (MaybeT (MaybeT, runMaybeT))
 import Data.IORef (IORef)
 import Data.IORef qualified as IORef

--- a/screach/test/distCLI/DistCLI.hs
+++ b/screach/test/distCLI/DistCLI.hs
@@ -8,7 +8,7 @@ module DistCLI (cli, DisttestConfig (..), runDistTest) where
 import Control.Applicative ((<|>))
 import Control.Monad qualified
 import Control.Monad.Reader (ReaderT (runReaderT))
-import Control.Monad.State.Lazy (evalStateT)
+import Control.Monad.State.Strict (evalStateT)
 import Data.ByteString qualified as BS
 import Data.IORef qualified as IORef
 import Data.List qualified as List


### PR DESCRIPTION
Benchmarking doesn't show a win, but knowing there's no latent space leak here will help me sleep easier at night. Fixes #585.