### PR TITLE
Lint with `tagref`

### DIFF
--- a/.github/ci.sh
+++ b/.github/ci.sh
@@ -10,7 +10,7 @@ BIN=${PWD}/bin
 is_exe() { [[ -x "$1/$2$EXT" ]] || command -v "$2" > /dev/null 2>&1; }
 
 # Create a grease.buildinfo.json file for the benefit of the Docker image.
-# (See Note [grease.buildinfo.json] in grease-cli/src/Grease/Version.hs.)
+# (See [ref:grease_buildinfo_json].)
 #
 # The first argument is the git commit, and the second argument is the git
 # branch name.

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,6 +79,21 @@ jobs:
         with:
           files: doc/
 
+      - name: Check cross-references with tagref
+        run: |
+          mkdir -p ~/.bin
+          curl \
+            --fail \
+            --location \
+            --proto '=https' \
+            --show-error \
+            --silent \
+            --tlsv1.2 \
+            https://github.com/stepchowfun/tagref/releases/download/v1.12.1/tagref-x86_64-unknown-linux-gnu > \
+            ~/.bin/tagref
+          chmod +x ~/.bin/tagref
+          ~/.bin/tagref
+
       - name: Find stale TODOs
         env:
           GH_TOKEN: ${{ github.token }}

--- a/doc/dev/lint.md
+++ b/doc/dev/lint.md
@@ -80,6 +80,34 @@ git ls-files -z --exclude-standard '*.py' | xargs -0 ruff check
 
 See the [Ghidra batch plugin docs](../ghidra-batch-plugin.md).
 
+## tagref
+
+We lint cross-references in code with [tagref].
+
+```sh
+tagref
+```
+
+tagref verifies that every reference refers to an existing tag, and that there
+are no duplicate tags. The following is the syntax of tags and references:
+
+- Tags: `[tag:snake_case_tag_name]`
+- References: `[ref:snake_case_tag_name]`
+
+tagref can also verify file and directory references (`file:` and `dir:`).
+
+We often `tag:` the documentation for a feature, and then use `ref:`erences in
+places in the code that have behavior described in the documentation. This helps
+us remember to update documentation when we update code, and signals to readers
+of the code that higher-level documentation that can provide valuable context is
+available elsewhere.
+
+We highly encourage extensive cross-referencing. It helps us keep documentation
+and code in sync, and reminds us what needs to be updated in other parts of the
+codebase when making changes.
+
+[tagref]: https://github.com/stepchowfun/tagref
+
 ## ttlint
 
 We lint text files with [ttlint].

--- a/doc/function-calls.md
+++ b/doc/function-calls.md
@@ -1,5 +1,7 @@
 # Function calls
 
+<!-- [tag: function_calls] -->
+
 GREASE's algorithm for handling function calls is as follows:
 
 - If the call is through a symbolic function pointer, then:

--- a/doc/memory-model.md
+++ b/doc/memory-model.md
@@ -54,6 +54,8 @@ Mutable global variables are tricky:
   analysis or its callees) will fail. As mutable global variables are pervasive,
   this would lead to a significant lack of coverage.
 
+<!-- [tag:globals_flag] -->
+
 GREASE's behavior in this regard is controlled via the `--globals` flag. The
 possible values are:
 
@@ -65,6 +67,8 @@ possible values are:
   globals will fail, causing GREASE to be unable to proceed with analysis.
 
 ## The stack
+
+<!-- [tag:stack] -->
 
 GREASE represents the stack as a separate Crucible-LLVM allocation. Before
 symbolically executing the target function, the stack pointer is initialized to

--- a/grease-cli/grease-cli.cabal
+++ b/grease-cli/grease-cli.cabal
@@ -163,6 +163,7 @@ library
     Grease.Cli.Enum
     Grease.Version
 
+  -- For Paths_*, see [ref:grease_buildinfo_json]
   autogen-modules:
     Paths_grease_cli
   other-modules:

--- a/grease-cli/src/Grease/Cli.hs
+++ b/grease-cli/src/Grease/Cli.hs
@@ -284,6 +284,7 @@ fsRootParser =
         )
     )
 
+-- [ref:globals_flag]
 globalsParser :: Opt.Parser GO.MutableGlobalState
 globalsParser =
   GCE.enumParserDefault

--- a/grease-cli/src/Grease/Version.hs
+++ b/grease-cli/src/Grease/Version.hs
@@ -39,7 +39,7 @@ commitHash :: String
 commitHash
   | hash /= unknown =
       hash
-  -- See Note [grease.buildinfo.json]
+  -- See [ref:grease_buildinfo_json]
   | Just buildinfoVal <- Aeson.decodeStrict buildinfo
   , Just (Aeson.String buildinfoHash) <- KeyMap.lookup "hash" buildinfoVal =
       Text.unpack buildinfoHash
@@ -53,7 +53,7 @@ commitBranch :: String
 commitBranch
   | branch /= unknown =
       branch
-  -- See Note [grease.buildinfo.json]
+  -- See [ref:grease_buildinfo_json]
   | Just buildinfoVal <- Aeson.decodeStrict buildinfo
   , Just (Aeson.String buildinfoCommit) <- KeyMap.lookup "branch" buildinfoVal =
       Text.unpack buildinfoCommit
@@ -67,7 +67,7 @@ commitDirty :: Bool
 commitDirty
   | dirty =
       dirty
-  -- See Note [grease.buildinfo.json]
+  -- See [ref:grease_buildinfo_json]
   | Just buildinfoVal <- Aeson.decodeStrict buildinfo
   , Just (Aeson.Bool buildinfoDirty) <- KeyMap.lookup "dirty" buildinfoVal =
       buildinfoDirty
@@ -85,12 +85,12 @@ unknown = "UNKNOWN"
 
 -- Helper, not exported
 --
--- See Note [grease.buildinfo.json]
+-- See [ref:grease_buildinfo_json]
 buildinfo :: BS.ByteString
 buildinfo = $(embedFileRelative "grease.buildinfo.json")
 
 {-
-Note [grease.buildinfo.json]
+[tag:grease_buildinfo_json]
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 By default, we determine the git commit hash, branch, and dirty information
 using the gitrev library, which invokes git at compile time to query the

--- a/grease/src/Grease/Macaw/ResolveCall.hs
+++ b/grease/src/Grease/Macaw/ResolveCall.hs
@@ -244,7 +244,7 @@ data LookupFunctionHandleResult p sym arch where
 
 -- | Attempt to look up a function handle.
 --
--- The behavior of this function is documented in @doc/function-calls.md@.
+-- The behavior of this function is documented at @[ref:function_calls]@.
 lookupFunctionHandleResult ::
   forall arch sym bak solver scope st fs p rtp blocks r ctx cExt ret t argTys wptr.
   ( OnlineSolverAndBackend solver sym bak scope st fs

--- a/grease/src/Grease/Shape/Pointer.hs
+++ b/grease/src/Grease/Shape/Pointer.hs
@@ -779,6 +779,8 @@ parseJsonPtrShape parseTag =
 --
 -- * A number of pointer-sized stack slocks, which are reserved for
 --   stack-spilled arguments.
+--
+-- This is documented at @[ref:stack]@.
 x64StackPtrShape ::
   -- | Initialize the end of the stack to a concrete sequence of bytes if the
   -- value is @Just@, otherwise initialize the end of the stack to 8 fresh,
@@ -808,6 +810,8 @@ x64StackPtrShape returnAddrBytes stackArgSlots =
 --
 -- * A number of pointer-sized stack slocks, which are reserved for
 --   stack-spilled arguments.
+--
+-- This is documented at @[ref:stack]@.
 ppcStackPtrShape ::
   CLM.HasPtrWidth wptr =>
   -- | Initialize the end of the stack to a concrete sequence of bytes if the
@@ -837,6 +841,8 @@ ppcStackPtrShape returnAddrBytes stackArgSlots =
 --
 -- Unlike the stack pointer in x86_64 and PowerPC, the AArch32 stack pointer
 -- does /not/ store the return address on the stack.
+--
+-- This is documented at @[ref:stack]@.
 armStackPtrShape ::
   ExtraStackSlots ->
   PtrShape ext wptr 'Precond NoTag (CLM.LLVMPointerType wptr)

--- a/lun.toml
+++ b/lun.toml
@@ -73,6 +73,9 @@ args = "all"
 files = ["**/Makefile", "*.cabal", "*.md", "*.mk", "*.project", "*.py", "*.scala", "*.sh"]
 
 [[tool]]
+name = "tagref"
+
+[[tool]]
 name = "ttlint"
 # some of these have significant trailing whitespace
 ignore = ["grease-exe/tests/**/*"]


### PR DESCRIPTION
`tagref` is a tool to check cross-references in code. It can be thought of as a machine-checkable generalization of our GHC-inspired `Note [Note name]` system of references.

This commit introduces a few example uses, we would expect to add many more in the course of development.

Fixes #567.