### PR TITLE
fix(python): Fix Ruff lints

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -79,6 +79,8 @@ jobs:
 
       - name: Install ruff
         uses: astral-sh/ruff-action@278981a28ce3188b1e39527901f38254bf3aac89 # v4.1.0
+        with:
+          version: "0.16.0"
 
       - name: Ensure python files are formatted
         run: ruff format --check --diff $(git ls-files '*.py')

--- a/ghidra_scripts/grease.py
+++ b/ghidra_scripts/grease.py
@@ -22,20 +22,12 @@
 # @menupath Tools.GREASE Analysis
 # @copyright Galois Inc. 2024
 
-# Many names are defined by Ghidra, but Ruff doesn't know that
-# Also allow star imports for builtin stubs
-# ruff: noqa: F821 F405 F403
-
-# This one is just too opinionated
-# ruff: noqa: E741
-
 import json
 import math
 import os
 import re
 import subprocess
 import tempfile
-
 
 try:
     import typing
@@ -54,11 +46,9 @@ if typing.TYPE_CHECKING:
     from ghidra.ghidra_builtins import *  # type: ignore
 
 
-from java.awt import Color
-
 from ghidra.app.plugin.core.analysis.rust.RustUtilities import isRustProgram
 from ghidra.app.util.opinion import ElfLoader
-
+from java.awt import Color
 
 ### CONSTANTS ###
 
@@ -168,7 +158,7 @@ def parseGreaseLocation(locationString):
 
 
 def indent(spaces, lines):
-    return "\n".join([" " * spaces + l for l in lines.strip().split("\n")])
+    return "\n".join([" " * spaces + line for line in lines.strip().split("\n")])
 
 
 ### PARSING GREASE RESULTS ###
@@ -399,7 +389,7 @@ def parseBatchBug(fnEntryPoint, greaseLoadOffset, batchBugJSON):
 
         # NOTE: we're explicitly encoding utf-8 here, as contents may include non-ascii characters.
         # TODO: how to handle this more generally?
-        if "bugUb" in bugDesc and bugDesc["bugUb"]:  # bugUb is nullable
+        if bugDesc.get("bugUb"):  # bugUb is nullable
             # Use a more specific bug type as the tag, if available
             tag = bugDesc["bugUb"]["ubType"]["tag"]
             details.extend(
@@ -489,7 +479,7 @@ def parseBatchCouldNotInfer(fnEntryPoint, greaseLoadOffset, failedPredicateJSONs
             location_addr = greaseOffsetToGhidraAddress(
                 greaseLoadOffset, parseGreaseLocation(p["_failedPredicateLocation"])
             )
-            location = location = "0x{:x}".format(location_addr.getOffset())
+            location = "0x{:x}".format(location_addr.getOffset())
             location_results.append(
                 GreaseInstructionResult(
                     "InferenceFailure", location_addr, p["_failedPredicateMessage"], []
@@ -681,14 +671,13 @@ def getGhidraInitialPrecondition(fn):
     )
 
     # Create initial preconditions file on disk & return filename
-    initial_precondition_file = tempfile.NamedTemporaryFile(delete=False)
-    print(
-        "Generating initial precondition file '{}' containing:\n{}".format(
-            initial_precondition_file.name, precondition_file_content
+    with tempfile.NamedTemporaryFile(delete=False) as initial_precondition_file:
+        print(
+            "Generating initial precondition file '{}' containing:\n{}".format(
+                initial_precondition_file.name, precondition_file_content
+            )
         )
-    )
-    initial_precondition_file.write(precondition_file_content)
-    initial_precondition_file.close()
+        initial_precondition_file.write(precondition_file_content)
     return initial_precondition_file.name
 
 

--- a/ghidra_scripts/ruff.toml
+++ b/ghidra_scripts/ruff.toml
@@ -1,0 +1,15 @@
+[lint]
+ignore = [
+    # Ghidra type stubs intentionally use a star import to describe script globals.
+    "F403",
+    # Ghidra injects these globals when it executes the script at runtime.
+    "F405",
+    # Ghidra's default Script Manager provider is Jython 2.7, which cannot parse f-strings.
+    "UP032",
+    # Omitting `object` would create an old-style class under Jython 2.7.
+    "UP004",
+    # Zero-argument `super()` is unsupported by Jython 2.7.
+    "UP008",
+    # Jython 2.7's math.ceil returns a float, so the int conversion is required.
+    "RUF046",
+]

--- a/grease-exe/tests/extract-cflags.py
+++ b/grease-exe/tests/extract-cflags.py
@@ -7,7 +7,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from sys import exit, stderr
 
-
 COMMENT = "// CFLAGS: "
 
 GROUPS = {"LLVM": ["-emit-llvm", "-frecord-command-line"]}

--- a/grease/benchmarks/bench.py
+++ b/grease/benchmarks/bench.py
@@ -56,6 +56,7 @@ def _run_benchmark(c_file: Path, elf_path: str) -> None:
         ]
         + grease_str.split(),
         capture_output=True,
+        check=False,
         text=True,
     )
     print(result.stdout, end="")

--- a/screach/test-data/extract-cflags.py
+++ b/screach/test-data/extract-cflags.py
@@ -11,7 +11,6 @@ from argparse import ArgumentParser
 from pathlib import Path
 from sys import exit, stderr
 
-
 COMMENT = "// CFLAGS: "
 
 GROUPS = {

--- a/screach/test-gen/callgraph-script/main.py
+++ b/screach/test-gen/callgraph-script/main.py
@@ -1,21 +1,22 @@
 """Generate tab separated callgraphs for tests in directed-test-data"""
 
+# Ghidra modules are available only after pyghidra.start() initializes the JVM.
+# ruff: isort: skip_file
+
+import argparse
+import os
+import typing
+from functools import partial
+
 import pyghidra
 
 pyghidra.start()
 
-import ghidra  # noqa: F401, E402
-from ghidra.program.flatapi import FlatProgramAPI  # noqa: E402
-from ghidra.program.model.listing import Function, Instruction  # noqa: E402
-from ghidra.app.util.opinion import ElfLoader  # noqa: E402
-from ghidra.program.model.address import Address  # noqa: E402
-from ghidra.program.model.listing import Program  # noqa: E402
-
-import argparse  # noqa: E402
-import os  # noqa: E402
-
-import typing  # noqa: E402
-from functools import partial  # noqa: E402
+from ghidra.app.util.opinion import ElfLoader
+from ghidra.program.model.address import Address
+from ghidra.program.flatapi import FlatProgramAPI
+from ghidra.program.model.listing import Function, Instruction
+from ghidra.program.model.listing import Program
 
 
 # This function does not succeed for
@@ -35,43 +36,43 @@ def main():
     prs.add_argument("--entrypoint", type=str)
     args = prs.parse_args()
     try:
-        with open(args.output, "w") as f:
-            with pyghidra.open_program(args.target_bin) as flat_api:
-                fapi = typing.cast(FlatProgramAPI, flat_api)
-                funcs = fapi.getGlobalFunctions(args.entrypoint)
-                if len(funcs) == 0:
-                    raise ValueError(f"Entrypoint: {args.entrypoint} not found")
+        with (
+            open(args.output, "w") as f,
+            pyghidra.open_program(args.target_bin) as flat_api,
+        ):
+            fapi = typing.cast(FlatProgramAPI, flat_api)
+            funcs = fapi.getGlobalFunctions(args.entrypoint)
+            if len(funcs) == 0:
+                raise ValueError(f"Entrypoint: {args.entrypoint} not found")
 
-                addrConv = partial(
-                    ghidraAddressToScreachOffset, fapi.getCurrentProgram()
+            addrConv = partial(ghidraAddressToScreachOffset, fapi.getCurrentProgram())
+            stack = list(funcs)
+            seen_functions = set()
+            while len(stack) != 0:
+                curr = typing.cast(Function, stack.pop())
+                seen_functions.add(curr)
+                insns = (
+                    fapi.getCurrentProgram()
+                    .getListing()
+                    .getInstructions(curr.getBody(), True)
                 )
-                stack = list(funcs)
-                seen_functions = set()
-                while len(stack) != 0:
-                    curr = typing.cast(Function, stack.pop())
-                    seen_functions.add(curr)
-                    insns = (
-                        fapi.getCurrentProgram()
-                        .getListing()
-                        .getInstructions(curr.getBody(), True)
-                    )
-                    for insn in insns:
-                        for ref in typing.cast(Instruction, insn).getReferencesFrom():
-                            if ref.getReferenceType().isCall():
-                                ent = curr.getEntryPoint()
-                                froma = ref.getFromAddress()
-                                toa = ref.getToAddress()
-                                print(
-                                    f"{addrConv(ent)}\t{addrConv(froma)}\t{addrConv(toa)}",
-                                    file=f,
-                                )
-                                called = fapi.getFunctionAt(ref.getToAddress())
-                                if called is not None and called not in seen_functions:
-                                    seen_functions.add(curr)
-                                    stack.append(called)
-    except Exception as e:
+                for insn in insns:
+                    for ref in typing.cast(Instruction, insn).getReferencesFrom():
+                        if ref.getReferenceType().isCall():
+                            ent = curr.getEntryPoint()
+                            froma = ref.getFromAddress()
+                            toa = ref.getToAddress()
+                            print(
+                                f"{addrConv(ent)}\t{addrConv(froma)}\t{addrConv(toa)}",
+                                file=f,
+                            )
+                            called = fapi.getFunctionAt(ref.getToAddress())
+                            if called is not None and called not in seen_functions:
+                                seen_functions.add(curr)
+                                stack.append(called)
+    except Exception:
         os.remove(args.output)
-        raise e
+        raise
 
 
 if __name__ == "__main__":

--- a/screach/test-gen/callgraph-script/ruff.toml
+++ b/screach/test-gen/callgraph-script/ruff.toml
@@ -1,0 +1,5 @@
+[lint]
+ignore = [
+    # Ghidra modules are available only after pyghidra.start() initializes the JVM.
+    "E402",
+]

--- a/scripts/lint/stale-todo.py
+++ b/scripts/lint/stale-todo.py
@@ -21,6 +21,7 @@ def status(no, /):
     result = run(
         ["gh", "issue", "view", no, "--json", "state", "--jq", ".state"],
         capture_output=True,
+        check=False,
         text=True,
     )
     out = result.stdout.strip()

--- a/scripts/perf.py
+++ b/scripts/perf.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python3
 """Collect and analyze deterministic performance metrics from GHC RTS output."""
 
-from dataclasses import dataclass
-from typing import Optional
 import re
 import subprocess
 import sys
 from argparse import ArgumentParser
+from dataclasses import dataclass
 
 
 @dataclass
@@ -90,12 +89,12 @@ def parse_rts_output(stderr: str) -> RTSStats:
     gen1_match = re.search(r"Gen\s+1\s+(\d+) colls", stderr)
     productivity_match = re.search(r"Productivity\s+([\d.]+)%", stderr)
 
-    def parse_number(match: Optional[re.Match]) -> int:
+    def parse_number(match: re.Match | None) -> int:
         if match is None:
             return 0
         return int(match.group(1).replace(",", ""))
 
-    def parse_float(match: Optional[re.Match]) -> float:
+    def parse_float(match: re.Match | None) -> float:
         if match is None:
             return 0.0
         return float(match.group(1))
@@ -135,7 +134,7 @@ def get_current_commit_info() -> tuple[str, str]:
     return ref, get_commit_sha()
 
 
-def checkout_ref(ref: Optional[str]) -> tuple[str, str]:
+def checkout_ref(ref: str | None) -> tuple[str, str]:
     """Checkout a git ref if specified, otherwise use current HEAD."""
     if ref is None:
         return get_current_commit_info()
@@ -159,6 +158,7 @@ def run_with_cabal(package: str, args: list[str]) -> tuple[str, int]:
     result = subprocess.run(
         cmd,
         capture_output=True,
+        check=False,
         text=True,
     )
 


### PR DESCRIPTION
The ruff action fetches the `latest` version of Ruff by default. This PR pins to 0.16.0 and fixes the new lints. These failures block non-Python changes like #739.