### PR TITLE
fix(ci): Use full version number in `setup-java` action comment

### DIFF
--- a/.github/actions/ghidra-install/action.yml
+++ b/.github/actions/ghidra-install/action.yml
@@ -7,7 +7,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup java
-      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'temurin'
         java-version: '21'


### PR DESCRIPTION
Follow-up to 8f10b454cad1a675691da8cfe02916e540df58f4. From that commit:

    Zizmor will (reasonably) complain if the SHA is not pointed to by
    that tag. Since tags in GHA repos are often moved, these can become
    out of date if they only specify the major version number (which is
    likely what happened here).

Enables #1761.